### PR TITLE
Adds DB & models for user, game, challenge, rating

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,7 +197,7 @@ dependencies = [
  "bytes",
  "bytestring",
  "cfg-if",
- "cookie",
+ "cookie 0.16.2",
  "derive_more",
  "encoding_rs",
  "futures-core",
@@ -355,6 +355,8 @@ dependencies = [
  "actix-files",
  "actix-web",
  "cfg-if",
+ "cookie 0.17.0",
+ "db",
  "hive",
  "http",
  "leptos",
@@ -459,6 +461,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
 
 [[package]]
+name = "bb8"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98b4b0f25f18bcdc3ac72bdb486ed0acf7e185221fd4dc985bc15db5800b0ba2"
+dependencies = [
+ "async-trait",
+ "futures-channel",
+ "futures-util",
+ "parking_lot",
+ "tokio",
+]
+
+[[package]]
 name = "bitfield-struct"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -553,6 +568,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
 name = "bytes"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -629,8 +650,10 @@ checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-targets",
 ]
 
@@ -699,7 +722,7 @@ dependencies = [
  "rust-ini",
  "serde",
  "serde_json",
- "toml",
+ "toml 0.5.11",
  "yaml-rust",
 ]
 
@@ -765,6 +788,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
 dependencies = [
  "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7efb37c3e1ccb1ff97164ad95ac1606e8ccd35b3fa0a7d99a304c7f4a428cc24"
+dependencies = [
  "time",
  "version_check",
 ]
@@ -893,6 +926,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "db"
+version = "0.1.0"
+dependencies = [
+ "bb8",
+ "chrono",
+ "diesel",
+ "diesel-async",
+ "diesel_migrations",
+ "dotenvy",
+ "hive",
+ "serde",
+ "skillratings",
+ "thiserror",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
 name = "default-struct-builder"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -938,6 +989,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "diesel"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53c8a2cb22327206568569e5a45bb5a2c946455efdd76e24d15b7e82171af95e"
+dependencies = [
+ "bitflags 2.4.0",
+ "byteorder",
+ "chrono",
+ "diesel_derives",
+ "itoa",
+ "pq-sys",
+ "uuid",
+]
+
+[[package]]
+name = "diesel-async"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acada1517534c92d3f382217b485db8a8638f111b0e3f2a2a8e26165050f77be"
+dependencies = [
+ "async-trait",
+ "bb8",
+ "diesel",
+ "futures-util",
+ "scoped-futures",
+ "tokio",
+ "tokio-postgres",
+]
+
+[[package]]
+name = "diesel_derives"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef8337737574f55a468005a83499da720f20c65586241ffea339db9ecdfd2b44"
+dependencies = [
+ "diesel_table_macro_syntax",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
+]
+
+[[package]]
+name = "diesel_migrations"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6036b3f0120c5961381b570ee20a02432d7e2d27ea60de9578799cf9156914ac"
+dependencies = [
+ "diesel",
+ "migrations_internals",
+ "migrations_macros",
+]
+
+[[package]]
+name = "diesel_table_macro_syntax"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc5557efc453706fed5e4fa85006fe9817c224c3f480a34c7e5959fd700921c5"
+dependencies = [
+ "syn 2.0.37",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -945,6 +1058,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -952,6 +1066,12 @@ name = "dlv-list"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
+
+[[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "drain_filter_polyfill"
@@ -1000,6 +1120,18 @@ dependencies = [
  "cc",
  "libc",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
+name = "finl_unicode"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fcfdc7a0362c9f4444381a9e697c79d435fe65b52a37466fc2c1184cee9edc6"
 
 [[package]]
 name = "flate2"
@@ -1268,6 +1400,15 @@ dependencies = [
  "serde",
  "serde_with",
  "thiserror",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
 ]
 
 [[package]]
@@ -1818,10 +1959,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
+
+[[package]]
 name = "memchr"
 version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
+
+[[package]]
+name = "migrations_internals"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f23f71580015254b020e856feac3df5878c2c7a8812297edd6c0a485ac9dada"
+dependencies = [
+ "serde",
+ "toml 0.7.8",
+]
+
+[[package]]
+name = "migrations_macros"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cce3325ac70e67bbab5bd837a31cae01f1a6db64e0e744a33cb03a543469ef08"
+dependencies = [
+ "migrations_internals",
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "mime"
@@ -1978,9 +2150,9 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pest"
-version = "2.7.3"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a4d085fd991ac8d5b05a147b437791b4260b76326baf0fc60cf7c9c27ecd33"
+checksum = "c022f1e7b65d6a24c0dbbd5fb344c66881bc01f3e5ae74a1c8100f2f985d98a4"
 dependencies = [
  "memchr",
  "thiserror",
@@ -1989,9 +2161,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.3"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2bee7be22ce7918f641a33f08e3f43388c7656772244e2bbb2477f44cc9021a"
+checksum = "35513f630d46400a977c4cb58f78e1bfbe01434316e60c37d27b9ad6139c66d8"
 dependencies = [
  "pest",
  "pest_generator",
@@ -1999,9 +2171,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.3"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1511785c5e98d79a05e8a6bc34b4ac2168a0e3e92161862030ad84daa223141"
+checksum = "bc9fc1b9e7057baba189b5c626e2d6f40681ae5b6eb064dc7c7834101ec8123a"
 dependencies = [
  "pest",
  "pest_meta",
@@ -2012,13 +2184,31 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.7.3"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42f0394d3123e33353ca5e1e89092e533d2cc490389f2bd6131c43c634ebc5f"
+checksum = "1df74e9e7ec4053ceb980e7c0c8bd3594e977fde1af91daba9c928e8e8c6708d"
 dependencies = [
  "once_cell",
  "pest",
  "sha2",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -2060,10 +2250,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
+name = "postgres-protocol"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49b6c5ef183cd3ab4ba005f1ca64c21e8bd97ce4699cfea9e8d9a2c4958ca520"
+dependencies = [
+ "base64 0.21.4",
+ "byteorder",
+ "bytes",
+ "fallible-iterator",
+ "hmac",
+ "md-5",
+ "memchr",
+ "rand",
+ "sha2",
+ "stringprep",
+]
+
+[[package]]
+name = "postgres-types"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d2234cdee9408b523530a9b6d2d6b373d1db34f6a8e51dc03ded1828d7fb67c"
+dependencies = [
+ "bytes",
+ "fallible-iterator",
+ "postgres-protocol",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "pq-sys"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31c0052426df997c0cbd30789eb44ca097e3541717a7b8fa36b1c464ee7edebd"
+dependencies = [
+ "vcpkg",
+]
 
 [[package]]
 name = "prettyplease"
@@ -2414,6 +2642,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-futures"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1473e24c637950c9bd38763220bea91ec3e095a89f672bbd7a10d03e77ba467"
+dependencies = [
+ "cfg-if",
+ "pin-utils",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2491,6 +2729,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_test"
 version = "1.0.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2550,6 +2797,7 @@ dependencies = [
  "actix-web",
  "actix-web-actors",
  "app",
+ "db",
  "leptos",
  "leptos_actix",
  "log",
@@ -2622,9 +2870,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.7"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2657,6 +2905,18 @@ dependencies = [
  "time",
  "windows-sys 0.42.0",
 ]
+
+[[package]]
+name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
+name = "skillratings"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82a9810ae02fd1f6d86c66fa7eebe1224576251ea9b0b62fa1f2ea29502599aa"
 
 [[package]]
 name = "slab"
@@ -2704,10 +2964,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "stringprep"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb41d74e231a107a1b4ee36bd1214b11285b77768d2e3824aedafa988fd36ee6"
+dependencies = [
+ "finl_unicode",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "subtle"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
@@ -2845,6 +3122,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-postgres"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d340244b32d920260ae7448cb72b6e238bddc3d4f7603394e7dd46ed8e48f5b8"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "fallible-iterator",
+ "futures-channel",
+ "futures-util",
+ "log",
+ "parking_lot",
+ "percent-encoding",
+ "phf",
+ "pin-project-lite",
+ "postgres-protocol",
+ "postgres-types",
+ "rand",
+ "socket2 0.5.4",
+ "tokio",
+ "tokio-util",
+ "whoami",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2865,6 +3168,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "toml"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.19.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+dependencies = [
+ "indexmap 2.0.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -3015,6 +3352,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3119,6 +3462,16 @@ checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "whoami"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22fc3756b8a9133049b26c7f61ab35416c130e8c09b660f5b3958b446f52cc50"
+dependencies = [
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -3283,6 +3636,15 @@ name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "winnow"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c2e3184b9c4e92ad5167ca73039d0c42476302ab603e2fec4487511f38ccefc"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["app", "frontend", "server", "engine"]
+members = ["app", "frontend", "server", "engine", "db"]
 resolver = "2"
 
 # need to be applied only to wasm build
@@ -26,11 +26,21 @@ console_log = "1.0.0"
 http = "0.2.9"
 log = "0.4.20"
 simple_logger = "4.2.0"
-thiserror = "1.0.48"
+thiserror = "1"
 tokio = { version = "1.32.0", features = ["full"] }
 wasm-bindgen = "=0.2.87"
 web-sys = {version = "0.3.6", features = ["AbortController", "AbortSignal", "HtmlDocument", "SvgPoint","SvgsvgElement", "SvgGraphicsElement", "SvgMatrix"] }
-uuid = { version = "1.4.1", features = ["v4", "wasm-bindgen", "serde"] }
+bb8 = { version = "0.8" }
+diesel = { version = "2.1", features = ["postgres", "chrono", "uuid"] }
+diesel-async = { version = "0.4", features = ["postgres", "bb8"] }
+diesel_migrations = { version = "2.1", features = ["postgres"]}
+uuid = { version = "1.4", features = ["v4", "wasm-bindgen", "serde"] }
+dotenvy = "0.15"
+lazy_static = "1.4"
+rand = "0.8"
+cookie = "0.17"
+skillratings = "0.25"
+chrono = { version = "0.4", features = ["serde"] }
 
 # See https://github.com/akesson/cargo-leptos for documentation of all the parameters.
 

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -20,12 +20,15 @@ http.workspace = true
 cfg-if.workspace = true
 thiserror.workspace = true
 uuid.workspace = true
+cookie.workspace = true
 hive = { path = "../engine" }
+db = { path = "../db", optional = true }
 
 [features]
 default = []
-hydrate = ["leptos/hydrate", "leptos_meta/hydrate", "leptos_router/hydrate"]
+hydrate = ["leptos/hydrate", "leptos_meta/hydrate", "leptos_router/hydrate",]
 ssr = [
+  "db",
   "dep:actix-files",
   "dep:actix-web",
   "dep:leptos_actix",

--- a/app/src/atoms/piece.rs
+++ b/app/src/atoms/piece.rs
@@ -47,7 +47,7 @@ pub fn Piece(
             }
             PieceType::Spawn => {
                 log!("Spawning piece {}", piece.get());
-                game_state.spawn_active_piece();
+                game_state.play_active_piece();
             }
             _ => log!("Piece is {}", piece_type),
         }

--- a/app/src/common/game_state.rs
+++ b/app/src/common/game_state.rs
@@ -24,8 +24,8 @@ impl GameStateSignal {
         self.signal.update(|s| s.reset())
     }
 
-    pub fn spawn_active_piece(&mut self) {
-        self.signal.update(|s| s.spawn_active_piece())
+    pub fn play_active_piece(&mut self) {
+        self.signal.update(|s| s.play_active_piece())
     }
 
     pub fn show_moves(&mut self, piece: Piece, position: Position) {
@@ -123,7 +123,7 @@ impl GameState {
         self.reserve_position = None;
     }
 
-    pub fn spawn_active_piece(&mut self) {
+    pub fn play_active_piece(&mut self) {
         if let (Some(active), Some(position)) = (self.active, self.target_position) {
             if let Err(e) = self.state.play_turn_from_position(active, position) {
                 log!("Could not play turn: {} {} {}", active, position, e);

--- a/app/src/functions/db.rs
+++ b/app/src/functions/db.rs
@@ -1,0 +1,9 @@
+use actix_web::web::Data;
+use db_lib::DbPool;
+use leptos::*;
+
+pub fn pool() -> Result<DbPool, ()> {
+    let req = use_context::<actix_web::HttpRequest>().expect("Failed to get req");
+    let pool = req.app_data::<Data<DbPool>>().expect("Failed to get Pool").get_ref().clone();
+    Ok(pool)
+}

--- a/app/src/functions/mod.rs
+++ b/app/src/functions/mod.rs
@@ -1,0 +1,2 @@
+#[cfg(feature = "ssr")]
+pub mod db;

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -8,10 +8,12 @@ use leptos_router::*;
 pub mod atoms;
 pub mod common;
 pub mod error_template;
+#[cfg(feature = "ssr")]
+pub mod functions;
 pub mod molecules;
 pub mod organisms;
 pub mod pages;
-use crate::pages::{home::Home, play::PlayPage, ws::WsPage};
+use crate::pages::{home::Home, play::PlayPage, ws::WsPage, user_create::UserCreate, user_get::UserGet};
 
 #[component]
 pub fn App() -> impl IntoView {
@@ -39,6 +41,8 @@ pub fn App() -> impl IntoView {
                     <Route path="" view=|| view! { <Home/> }/>
                     <Route path="/play" view=|| view! { <PlayPage/> }/>
                     <Route path="/hws" view=|| view! { <WsPage/> }/>
+                    <Route path="/user" view=|| view! { <UserCreate/> }/>
+                    <Route path="/user_get" view=|| view! { <UserGet/> }/>
                 </Routes>
             </main>
         </Router>

--- a/app/src/organisms/header.rs
+++ b/app/src/organisms/header.rs
@@ -14,6 +14,12 @@ pub fn Header() -> impl IntoView {
             <a href="/hws">
                 WebSocket
             </a>
+            <a href="/user">
+                User
+            </a>
+            <a href="/user_get">
+                UserGet
+            </a>
             <DarkModeToggle/>
         </header>
     }

--- a/app/src/pages/mod.rs
+++ b/app/src/pages/mod.rs
@@ -1,4 +1,5 @@
-pub mod play;
 pub mod home;
-pub mod ws;
+pub mod play;
 pub mod user_create;
+pub mod user_get;
+pub mod ws;

--- a/app/src/pages/user_create.rs
+++ b/app/src/pages/user_create.rs
@@ -1,29 +1,107 @@
 use crate::organisms::header::Header;
 use leptos::*;
-
+use leptos_router::ActionForm;
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct User {
-    username: String,
+    pub username: String,
+    pub id: String,
 }
 
-
-#[server(CreateUser, "/api")]
+#[server(CreateUser)]
 pub async fn create_user(username: String) -> Result<User, ServerFnError> {
-    Ok(User { username })
+    use actix_web::http::header::{HeaderMap, HeaderValue, SET_COOKIE};
+    use leptos_actix::{ResponseOptions, ResponseParts};
+
+    let response =
+        use_context::<ResponseOptions>().expect("to have leptos_actix::ResponseOptions provided");
+    let mut response_parts = ResponseParts::default();
+    let mut headers = HeaderMap::new();
+    let user_id = Uuid::new_v4().to_string();
+    headers.insert(
+        SET_COOKIE,
+        HeaderValue::from_str(&format!("user_id={user_id}; Path=/"))
+            .expect("to create header value"),
+    );
+    headers.append(
+        SET_COOKIE,
+        HeaderValue::from_str(&format!("username={username}; Path=/"))
+            .expect("to create header value"),
+    );
+    response_parts.headers = headers;
+
+    response.overwrite(response_parts);
+    Ok(User {
+        username,
+        id: user_id,
+    })
+}
+
+#[cfg(not(feature = "ssr"))]
+fn username_from_cookie() -> Option<String> {
+    use cookie::*;
+    use wasm_bindgen::JsCast;
+
+    let doc = document().unchecked_into::<web_sys::HtmlDocument>();
+    for cookie in Cookie::split_parse(doc.cookie().unwrap_or_default()) {
+        if let Ok(cookie) = cookie {
+            match cookie.name() {
+                "username" => return Some(cookie.value().to_string()),
+                _ => {}
+            }
+        }
+    }
+    None
+}
+
+#[cfg(feature = "ssr")]
+fn username_from_cookie() -> Option<String> {
+    use_context::<actix_web::HttpRequest>()
+        .and_then(|req| {
+            req.cookies()
+                .map(|cookies| {
+                    cookies.iter().find_map(|cookie| {
+                        if cookie.name() == "username" {
+                            Some(cookie.value().to_string())
+                        } else {
+                            None
+                        }
+                    })
+                })
+                .ok()
+        })
+        .unwrap_or(None)
 }
 
 #[component]
 pub fn UserCreate() -> impl IntoView {
+    let maybe_username = username_from_cookie();
+    let get_user = create_server_action::<CreateUser>();
+    // holds the latest *returned* value from the server
+    let value = get_user.value();
+    // check if the server has returned an error
+    // let has_error = move || value.with(|val| matches!(val, Some(Err(_))));
+
+    let username = move || {
+        match value() {
+            Some(Ok(user)) => user.username,
+            // otherwise, use the initial value
+            _ => maybe_username.to_owned().unwrap_or_default(),
+        }
+    };
+
     view! {
         <Header/>
-        <button on:click=move |_| {
-            // spawn_local(async {
-            //     create_user("leex".to_string()).await
-            // });
-        }>
-        "create user"
-        </button>
+        <ActionForm action=get_user>
+            <label>
+                "Create a user"
+                // `title` matches the `title` argument to `add_todo`
+                <input type="text" name="username"/>
+            </label>
+            <input type="submit" value="Create"/>
+        </ActionForm>
+        <p> { username } </p>
     }
 }

--- a/app/src/pages/user_get.rs
+++ b/app/src/pages/user_get.rs
@@ -1,0 +1,39 @@
+use crate::organisms::header::Header;
+use crate::pages::user_create::User as LeptosUser;
+use leptos_router::ActionForm;
+use leptos::*;
+
+#[server(GetUser)]
+pub async fn get_user() -> Result<LeptosUser, ServerFnError> {
+    use crate::functions::db::pool;
+    let pool = pool().expect("Failed to get pool");
+
+    use db_lib::models::user::User;
+    let user = User::find_by_uid("unique", &pool)
+        .await
+        .expect("Couldn't get user");
+    Ok(LeptosUser {
+        username: user.username,
+        id: user.uid,
+    })
+}
+
+#[component]
+pub fn UserGet() -> impl IntoView {
+    let get_user_action = create_server_action::<GetUser>();
+    let value = get_user_action.value();
+    let username = move || {
+        match value() {
+            Some(Ok(user)) => user.username,
+            _ => String::new(),
+        }
+    };
+
+    view! {
+        <Header/>
+        <ActionForm action=get_user_action>
+            <input type="submit" value="Get User"/>
+        </ActionForm>
+        <p> {username} </p>
+    }
+}

--- a/db/.env
+++ b/db/.env
@@ -1,0 +1,2 @@
+DATABASE_URL="postgres://hive-dev@localhost:/hive-local"
+TEST_DATABASE_URL="postgres://hive-dev@localhost:/hive-test"

--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "db"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+name = "db_lib"
+path = "src/lib.rs"
+
+[[bin]]
+name = "db_bin"
+path = "src/main.rs"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+bb8.workspace = true
+diesel.workspace = true
+diesel-async.workspace = true
+diesel_migrations.workspace = true
+uuid.workspace = true
+dotenvy.workspace = true
+thiserror.workspace = true
+serde.workspace = true
+tokio.workspace = true
+hive = { path = "../engine/" }
+skillratings.workspace = true
+chrono.workspace = true

--- a/db/diesel.toml
+++ b/db/diesel.toml
@@ -1,0 +1,5 @@
+[print_schema]
+file = "src/schema.rs"
+
+[migrations_directory]
+dir = "migrations"

--- a/db/migrations/00000000000000_diesel_initial_setup/down.sql
+++ b/db/migrations/00000000000000_diesel_initial_setup/down.sql
@@ -1,0 +1,6 @@
+-- This file was automatically created by Diesel to setup helper functions
+-- and other internal bookkeeping. This file is safe to edit, any future
+-- changes will be added to existing projects as new migrations.
+
+DROP FUNCTION IF EXISTS diesel_manage_updated_at(_tbl regclass);
+DROP FUNCTION IF EXISTS diesel_set_updated_at();

--- a/db/migrations/00000000000000_diesel_initial_setup/up.sql
+++ b/db/migrations/00000000000000_diesel_initial_setup/up.sql
@@ -1,0 +1,36 @@
+-- This file was automatically created by Diesel to setup helper functions
+-- and other internal bookkeeping. This file is safe to edit, any future
+-- changes will be added to existing projects as new migrations.
+
+
+
+
+-- Sets up a trigger for the given table to automatically set a column called
+-- `updated_at` whenever the row is modified (unless `updated_at` was included
+-- in the modified columns)
+--
+-- # Example
+--
+-- ```sql
+-- CREATE TABLE users (id SERIAL PRIMARY KEY, updated_at TIMESTAMP NOT NULL DEFAULT NOW());
+--
+-- SELECT diesel_manage_updated_at('users');
+-- ```
+CREATE OR REPLACE FUNCTION diesel_manage_updated_at(_tbl regclass) RETURNS VOID AS $$
+BEGIN
+    EXECUTE format('CREATE TRIGGER set_updated_at BEFORE UPDATE ON %s
+                    FOR EACH ROW EXECUTE PROCEDURE diesel_set_updated_at()', _tbl);
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION diesel_set_updated_at() RETURNS trigger AS $$
+BEGIN
+    IF (
+        NEW IS DISTINCT FROM OLD AND
+        NEW.updated_at IS NOT DISTINCT FROM OLD.updated_at
+    ) THEN
+        NEW.updated_at := current_timestamp;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/db/migrations/2023-09-26-143912_users/down.sql
+++ b/db/migrations/2023-09-26-143912_users/down.sql
@@ -1,0 +1,1 @@
+drop table users

--- a/db/migrations/2023-09-26-143912_users/up.sql
+++ b/db/migrations/2023-09-26-143912_users/up.sql
@@ -1,0 +1,6 @@
+create table users (
+    uid text primary key not null,
+    username text not null unique,
+    password text not null,
+    token text not null
+)

--- a/db/migrations/2023-09-27-085231_games/down.sql
+++ b/db/migrations/2023-09-27-085231_games/down.sql
@@ -1,0 +1,1 @@
+drop table games;

--- a/db/migrations/2023-09-27-085231_games/up.sql
+++ b/db/migrations/2023-09-27-085231_games/up.sql
@@ -1,0 +1,16 @@
+create table games (
+  id int generated always as identity primary key,
+  black_uid text not null,
+  game_status text not null,
+  game_type text not null,
+  history text not null,
+  game_control_history text not null,
+  rated boolean not null default true,
+  tournament_queen_rule boolean not null default true,
+  turn integer not null default 0,
+  white_uid text not null,
+  white_rating float8,
+  black_rating float8,
+  white_rating_change float8,
+  black_rating_change float8
+);

--- a/db/migrations/2023-09-27-092210_games_users/down.sql
+++ b/db/migrations/2023-09-27-092210_games_users/down.sql
@@ -1,0 +1,1 @@
+drop table games_users;

--- a/db/migrations/2023-09-27-092210_games_users/up.sql
+++ b/db/migrations/2023-09-27-092210_games_users/up.sql
@@ -1,0 +1,5 @@
+create table games_users (
+  game_id int references games(id) on delete cascade,
+  user_uid text references users(uid),
+  primary key(game_id, user_uid)
+);

--- a/db/migrations/2023-09-27-092621_ratings/down.sql
+++ b/db/migrations/2023-09-27-092621_ratings/down.sql
@@ -1,0 +1,1 @@
+drop table ratings;

--- a/db/migrations/2023-09-27-092621_ratings/up.sql
+++ b/db/migrations/2023-09-27-092621_ratings/up.sql
@@ -1,0 +1,12 @@
+create table ratings (
+  id int generated always as identity primary key,
+  user_uid text references users(uid) on delete cascade not null,
+  -- only PLM will be rated (for now?)
+  played int8 not null default 0,
+  won int8 not null default 0,
+  lost int8 not null default 0,
+  draw int8 not null default 0,
+  rating float8 not null default 1500.0,
+  deviation float8 not null default 350.0,
+  volatility float8 not null default 0.06
+);

--- a/db/migrations/2023-09-27-104218_challenges/down.sql
+++ b/db/migrations/2023-09-27-104218_challenges/down.sql
@@ -1,0 +1,1 @@
+drop table challenges;

--- a/db/migrations/2023-09-27-104218_challenges/up.sql
+++ b/db/migrations/2023-09-27-104218_challenges/up.sql
@@ -1,0 +1,10 @@
+create table challenges (
+    id uuid default gen_random_uuid() primary key not null,
+    challenger_uid text references users(uid) not null,
+    game_type text not null,
+    rated boolean not null,
+    public boolean not null,
+    tournament_queen_rule boolean not null,
+    color_choice text not null,
+    created_at timestamp with time zone not null
+)

--- a/db/src/config.rs
+++ b/db/src/config.rs
@@ -1,0 +1,26 @@
+use dotenvy::dotenv;
+use std::{env, env::VarError};
+
+#[derive(Clone, Debug)]
+pub struct DbConfig {
+    pub database_url: String,
+}
+
+impl DbConfig {
+    pub fn from_env() -> Result<DbConfig, VarError> {
+        dotenv().ok();
+        Ok(DbConfig {
+            database_url: env::var("DATABASE_URL")?,
+        })
+    }
+
+    pub fn from_test_env() -> Result<DbConfig, VarError> {
+        dotenv().ok();
+        if cfg!(test) {
+            return Ok(DbConfig {
+                database_url: env::var("TEST_DATABASE_URL")?,
+            });
+        }
+        unreachable!("You called a test function in a non test binary!");
+    }
+}

--- a/db/src/error.rs
+++ b/db/src/error.rs
@@ -1,0 +1,10 @@
+use diesel::result::Error as DieselError;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum DbError {
+    #[error("invalid field {field}: {reason}")]
+    UserInputError { field: String, reason: String },
+    #[error("Database error: {0}")]
+    DatabaseError(#[from] DieselError),
+}

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -1,0 +1,24 @@
+use bb8::PooledConnection;
+use diesel::result::{Error as DieselError, Error::QueryBuilderError};
+use diesel_async::{
+    pg::AsyncPgConnection,
+    pooled_connection::{bb8::Pool, AsyncDieselConnectionManager, PoolError},
+};
+
+pub mod config;
+pub mod error;
+pub mod models;
+pub mod schema;
+
+pub type DbPool = Pool<AsyncPgConnection>;
+
+pub async fn get_pool(db_uri: &str) -> Result<DbPool, PoolError> {
+    let manager = AsyncDieselConnectionManager::<AsyncPgConnection>::new(db_uri);
+    Pool::builder().build(manager).await
+}
+
+pub async fn get_conn(
+    pool: &DbPool,
+) -> Result<PooledConnection<AsyncDieselConnectionManager<AsyncPgConnection>>, DieselError> {
+    pool.get().await.map_err(|e| QueryBuilderError(e.into()))
+}

--- a/db/src/main.rs
+++ b/db/src/main.rs
@@ -1,0 +1,23 @@
+use db_lib::config::DbConfig;
+use db_lib::models::user::User;
+use db_lib::get_pool;
+
+#[tokio::main]
+async fn main() {
+    let config = DbConfig::from_env().expect("Failed to load config from env");
+    let pool = &get_pool(&config.database_url)
+        .await
+        .expect("Failed to get pool");
+    let uuid = "unique";
+    let user = User::new(uuid, "leex", "hunter2", "token").expect("Failed to make user");
+    user.insert(pool).await.expect("Failed to insert User");
+    println!("{:?}", user);
+    let found = User::find_by_uid(uuid, pool)
+        .await
+        .expect("Couldn't find user");
+    println!("{:?}", found);
+    // let deleted = found.delete(pool).await.expect("Failed to delete user");
+    // println!("{:?}", deleted);
+}
+
+

--- a/db/src/models/challenge.rs
+++ b/db/src/models/challenge.rs
@@ -1,0 +1,86 @@
+use crate::schema::{challenges, users};
+use crate::{get_conn, DbPool};
+use crate::models::user::User;
+use chrono::prelude::*;
+use diesel::prelude::*;
+use diesel::result::Error;
+use diesel_async::RunQueryDsl;
+use serde::Serialize;
+use uuid::Uuid;
+
+#[derive(Insertable, Debug)]
+#[diesel(table_name = challenges)]
+pub struct NewChallenge {
+    pub challenger_uid: String,
+    pub game_type: String,
+    pub rated: bool,
+    pub public: bool,
+    pub tournament_queen_rule: bool,
+    pub color_choice: String,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Associations, Identifiable, Queryable, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+#[diesel(belongs_to(User, foreign_key = challenger_uid))]
+#[diesel(table_name = challenges)]
+pub struct Challenge {
+    pub id: Uuid,
+    pub challenger_uid: String,
+    pub game_type: String,
+    pub rated: bool,
+    pub public: bool,
+    pub tournament_queen_rule: bool,
+    pub color_choice: String,
+    // TODO: periodically cleanup expired challanges
+    pub created_at: DateTime<Utc>,
+}
+
+impl Challenge {
+    pub async fn create(
+        challenger: &User,
+        challenge_request: &NewChallenge,
+        pool: &DbPool,
+    ) -> Result<Challenge, Error> {
+        let conn = &mut get_conn(pool).await?;
+        let new_challenge = NewChallenge {
+            challenger_uid: challenger.uid.to_string(),
+            color_choice: challenge_request.color_choice.to_string(),
+            game_type: challenge_request.game_type.to_string(),
+            rated: challenge_request.rated,
+            public: challenge_request.public,
+            tournament_queen_rule: challenge_request.tournament_queen_rule,
+            created_at: Utc::now(),
+        };
+        diesel::insert_into(challenges::table)
+            .values(&new_challenge)
+            .get_result(conn)
+            .await
+    }
+
+    pub async fn get_public(pool: &DbPool) -> Result<Vec<Challenge>, Error> {
+        let conn = &mut get_conn(pool).await?;
+        challenges::table
+            .filter(challenges::public.eq(true))
+            .get_results(conn)
+            .await
+    }
+
+    pub async fn get(id: &Uuid, pool: &DbPool) -> Result<Challenge, Error> {
+        let conn = &mut get_conn(pool).await?;
+        challenges::table.find(id).first(conn).await
+    }
+
+    pub async fn get_challenger(&self, pool: &DbPool) -> Result<User, Error> {
+        let conn = &mut get_conn(pool).await?;
+        users::table.find(&self.challenger_uid).first(conn).await
+    }
+
+    pub async fn delete(&self, pool: &DbPool) -> Result<(), Error> {
+        let conn = &mut get_conn(pool).await?;
+        diesel::delete(challenges::table.find(self.id))
+            .execute(conn)
+            .await?;
+        Ok(())
+    }
+}

--- a/db/src/models/game.rs
+++ b/db/src/models/game.rs
@@ -1,0 +1,302 @@
+use crate::{
+    get_conn,
+    models::{game_user::GameUser, rating::Rating},
+    schema::games,
+    schema::games::dsl::*,
+    DbPool,
+};
+use diesel::{prelude::*, result::Error, Identifiable, Insertable, QueryDsl, Queryable};
+use diesel_async::scoped_futures::ScopedFutureExt;
+use diesel_async::AsyncConnection;
+use diesel_async::RunQueryDsl;
+use hive_lib::{
+    color::Color, game_control::GameControl, game_result::GameResult, game_status::GameStatus,
+};
+use serde::{Deserialize, Serialize};
+use std::str::FromStr;
+
+#[derive(Insertable, Debug)]
+#[diesel(table_name = games)]
+pub struct NewGame {
+    pub black_uid: String, // uid of user
+    pub game_status: String,
+    pub game_type: String,
+    pub history: String,
+    pub game_control_history: String,
+    pub rated: bool,
+    pub tournament_queen_rule: bool,
+    pub turn: i32,
+    pub white_uid: String, // uid of user
+    pub white_rating: Option<f64>,
+    pub black_rating: Option<f64>,
+    pub white_rating_change: Option<f64>,
+    pub black_rating_change: Option<f64>,
+}
+
+#[derive(
+    Queryable, Identifiable, Serialize, Clone, Deserialize, Debug, AsChangeset, Selectable,
+)]
+#[diesel(primary_key(id))]
+#[diesel(table_name = games)]
+pub struct Game {
+    pub id: i32,
+    pub black_uid: String, // uid of user
+    pub game_status: String,
+    pub game_type: String,
+    pub history: String, //"piece pos;piece pos;piece pos;"
+    pub game_control_history: String,
+    pub rated: bool,
+    pub tournament_queen_rule: bool,
+    pub turn: i32,
+    pub white_uid: String, // uid of user
+    pub white_rating: Option<f64>,
+    pub black_rating: Option<f64>,
+    pub white_rating_change: Option<f64>,
+    pub black_rating_change: Option<f64>,
+}
+
+impl Game {
+    pub async fn create(new_game: &NewGame, pool: &DbPool) -> Result<Game, Error> {
+        let conn = &mut get_conn(pool).await?;
+        let game: Game = new_game.insert_into(games::table).get_result(conn).await?;
+        let game_user_white = GameUser::new(game.id, game.white_uid.clone());
+        game_user_white.insert(pool).await?;
+        let game_user_black = GameUser::new(game.id, game.black_uid.clone());
+        game_user_black.insert(pool).await?;
+        Ok(game)
+    }
+
+    pub async fn make_move(
+        &self,
+        mut board_move: String,
+        new_game_status: GameStatus,
+        pool: &DbPool,
+    ) -> Result<Game, Error> {
+        let connection = &mut get_conn(pool).await?;
+        if board_move.chars().last().unwrap_or(' ') != ';' {
+            board_move = format!("{board_move};");
+        }
+        let mut game_control_string = String::new();
+        if self.has_unanswered_game_control() {
+            let gc = match self.last_game_control() {
+                Some(GameControl::TakebackRequest(color)) => {
+                    GameControl::TakebackReject(Color::from(color.opposite()))
+                }
+                Some(GameControl::DrawOffer(color)) => {
+                    GameControl::DrawReject(Color::from(color.opposite()))
+                }
+                _ => unreachable!(),
+            };
+            game_control_string = format!("{}. {gc};", self.turn);
+        }
+
+        connection
+            .transaction::<_, diesel::result::Error, _>(|conn| {
+                async move {
+                    let changes: Option<(f64, f64)> =
+                        if let GameStatus::Finished(game_result) = new_game_status.clone() {
+                            if let GameResult::Unknown = game_result {
+                                None
+                            } else {
+                                Rating::update(
+                                    self.rated,
+                                    self.white_uid.clone(),
+                                    self.black_uid.clone(),
+                                    game_result,
+                                    conn,
+                                )
+                                .await?
+                            }
+                        } else {
+                            None
+                        };
+                    let (w_change, b_change) = if let Some((white_change, black_change)) = changes {
+                        (Some(white_change), Some(black_change))
+                    } else {
+                        (None, None)
+                    };
+                    let game = diesel::update(games::table.find(self.id))
+                        .set((
+                            history.eq(history.concat(board_move)),
+                            turn.eq(turn + 1),
+                            game_status.eq(new_game_status.to_string()),
+                            game_control_history
+                                .eq(game_control_history.concat(game_control_string)),
+                            white_rating_change.eq(w_change),
+                            black_rating_change.eq(b_change),
+                        ))
+                        .get_result(conn)
+                        .await?;
+                    Ok(game)
+                }
+                .scope_boxed()
+            })
+            .await
+    }
+
+    pub fn has_unanswered_game_control(&self) -> bool {
+        if let Some(gc) = self.last_game_control() {
+            return matches!(
+                gc,
+                GameControl::TakebackRequest(_) | GameControl::DrawOffer(_)
+            );
+        }
+        false
+    }
+
+    pub fn last_game_control(&self) -> Option<GameControl> {
+        if let Some(last) = self.game_control_history.split_terminator(';').last() {
+            if let Some(gc) = last.split(' ').last() {
+                return Some(
+                    GameControl::from_str(gc)
+                        .expect("Could not get GameControl from game_control_history"),
+                );
+            }
+        }
+        None
+    }
+
+    pub async fn write_game_control(
+        &self,
+        game_control: GameControl,
+        pool: &DbPool,
+    ) -> Result<Game, Error> {
+        let conn = &mut get_conn(pool).await?;
+        let game_control_string = format!("{}. {game_control};", self.turn);
+        diesel::update(games::table.find(self.id))
+            .set(game_control_history.eq(game_control_history.concat(game_control_string)))
+            .get_result(conn)
+            .await
+    }
+
+    pub async fn accept_takeback(
+        &self,
+        new_history: String,
+        new_game_status: String,
+        game_control: GameControl,
+        pool: &DbPool,
+    ) -> Result<Game, Error> {
+        let conn = &mut get_conn(pool).await?;
+        let game_control_string = format!("{}. {game_control};", self.turn);
+
+        diesel::update(games::table.find(self.id))
+            .set((
+                history.eq(new_history),
+                turn.eq(turn - 1),
+                game_status.eq(new_game_status),
+                game_control_history.eq(game_control_history.concat(game_control_string)),
+            ))
+            .get_result(conn)
+            .await
+    }
+
+    pub async fn resign(
+        &self,
+        game_control: GameControl,
+        new_game_status: GameStatus,
+        pool: &DbPool,
+    ) -> Result<Game, Error> {
+        let connection = &mut get_conn(pool).await?;
+        let game_control_string = format!("{}. {game_control};", self.turn);
+
+        connection
+            .transaction::<_, diesel::result::Error, _>(|conn| {
+                async move {
+                    let changes: Option<(f64, f64)> = match new_game_status.clone() {
+                        GameStatus::Finished(game_result) => {
+                            Rating::update(
+                                self.rated,
+                                self.white_uid.clone(),
+                                self.black_uid.clone(),
+                                game_result.clone(),
+                                conn,
+                            )
+                            .await?
+                        }
+                        _ => unreachable!(),
+                    };
+
+                    let (w_change, b_change) = if let Some((white_change, black_change)) = changes {
+                        (Some(white_change), Some(black_change))
+                    } else {
+                        (None, None)
+                    };
+
+                    let game = diesel::update(games::table.find(self.id))
+                        .set((
+                            game_status.eq(new_game_status.to_string()),
+                            game_control_history
+                                .eq(game_control_history.concat(game_control_string)),
+                            white_rating_change.eq(w_change),
+                            black_rating_change.eq(b_change),
+                        ))
+                        .get_result(conn)
+                        .await?;
+                    Ok(game)
+                }
+                .scope_boxed()
+            })
+            .await
+    }
+
+    pub async fn accept_draw(
+        &self,
+        game_control: GameControl,
+        pool: &DbPool,
+    ) -> Result<Game, Error> {
+        let connection = &mut get_conn(pool).await?;
+        let game_control_string = format!("{}. {game_control};", self.turn);
+        connection
+            .transaction::<_, diesel::result::Error, _>(|conn| {
+                async move {
+                    let changes: Option<(f64, f64)> = Rating::update(
+                        self.rated,
+                        self.white_uid.clone(),
+                        self.black_uid.clone(),
+                        GameResult::Draw,
+                        conn,
+                    )
+                    .await?;
+                    let (w_change, b_change) = if let Some((white_change, black_change)) = changes {
+                        (Some(white_change), Some(black_change))
+                    } else {
+                        (None, None)
+                    };
+                    let game = diesel::update(games::table.find(self.id))
+                        .set((
+                            game_control_history
+                                .eq(game_control_history.concat(game_control_string)),
+                            game_status.eq(GameStatus::Finished(GameResult::Draw).to_string()),
+                            white_rating_change.eq(w_change),
+                            black_rating_change.eq(b_change),
+                        ))
+                        .get_result(conn)
+                        .await?;
+                    Ok(game)
+                }
+                .scope_boxed()
+            })
+            .await
+    }
+
+    pub async fn set_status(&self, status: GameStatus, pool: &DbPool) -> Result<Game, Error> {
+        let conn = &mut get_conn(pool).await?;
+        diesel::update(games::table.find(self.id))
+            .set(game_status.eq(status.to_string()))
+            .get_result(conn)
+            .await
+    }
+
+    pub async fn get(other_id: i32, pool: &DbPool) -> Result<Game, Error> {
+        let conn = &mut get_conn(pool).await?;
+        games::table.find(other_id).first(conn).await
+    }
+
+    pub async fn delete(&self, pool: &DbPool) -> Result<(), Error> {
+        let conn = &mut get_conn(pool).await?;
+        diesel::delete(games::table.find(self.id))
+            .execute(conn)
+            .await?;
+        Ok(())
+    }
+}

--- a/db/src/models/game_user.rs
+++ b/db/src/models/game_user.rs
@@ -1,0 +1,27 @@
+use crate::schema::{games_users, games_users::dsl::games_users as games_users_table};
+use crate::models::{game::Game, user::User};
+use crate::{DbPool, get_conn};
+use diesel::{prelude::*, result::Error, Identifiable, Insertable, Queryable};
+use diesel_async::RunQueryDsl;
+
+#[derive(Insertable, Identifiable, Selectable, Queryable, Associations, Debug, Clone)]
+#[diesel(belongs_to(User, foreign_key = user_uid))]
+#[diesel(belongs_to(Game))]
+#[diesel(table_name = games_users)]
+#[diesel(primary_key(game_id, user_uid))]
+pub struct GameUser {
+    pub game_id: i32,
+    pub user_uid: String,
+}
+
+impl GameUser {
+    pub fn new(game_id: i32, user_uid: String) -> Self {
+        Self { game_id, user_uid }
+    }
+
+    pub async fn insert(&self, pool: &DbPool) -> Result<(), Error> {
+        let conn = &mut get_conn(pool).await?;
+        self.insert_into(games_users_table).execute(conn).await?;
+        Ok(())
+    }
+}

--- a/db/src/models/mod.rs
+++ b/db/src/models/mod.rs
@@ -1,0 +1,5 @@
+pub mod user;
+pub mod game;
+pub mod rating;
+pub mod game_user;
+pub mod challenge;

--- a/db/src/models/rating.rs
+++ b/db/src/models/rating.rs
@@ -1,0 +1,257 @@
+use crate::models::user::User;
+use crate::schema::ratings::{*, self};
+use crate::schema::ratings::dsl::ratings as ratings_table;
+use crate::{get_conn, DbPool};
+use diesel::{
+    prelude::*, result::Error, AsChangeset, Associations, Identifiable, Insertable, QueryDsl,
+    Queryable, Selectable,
+};
+use bb8::PooledConnection;
+use diesel_async::{RunQueryDsl, pooled_connection::AsyncDieselConnectionManager, AsyncPgConnection};
+use hive_lib::{color::Color, game_result::GameResult};
+use serde::{Deserialize, Serialize};
+use skillratings::{
+    glicko2::{glicko2, Glicko2Config, Glicko2Rating},
+    Outcomes,
+};
+
+#[derive(Insertable, Debug)]
+#[diesel(table_name = ratings)]
+pub struct NewRating {
+    pub user_uid: String,
+    pub played: i64,
+    pub won: i64,
+    pub lost: i64,
+    pub draw: i64,
+    pub rating: f64,
+    pub deviation: f64,
+    pub volatility: f64,
+}
+
+impl NewRating {
+    pub fn for_uid(user: &str) -> Self {
+        Self {
+            user_uid: user.to_string(),
+            played: 0,
+            won: 0,
+            lost: 0,
+            draw: 0,
+            rating: 1500.0,
+            deviation: 350.0,
+            volatility: 0.06,
+        }
+    }
+}
+
+#[derive(
+    Associations,
+    Identifiable,
+    Queryable,
+    Debug,
+    Serialize,
+    Deserialize,
+    AsChangeset,
+    Selectable,
+    PartialEq,
+)]
+#[serde(rename_all = "camelCase")]
+#[diesel(belongs_to(User, foreign_key = user_uid))]
+#[diesel(table_name = ratings)]
+#[diesel(primary_key(id))]
+pub struct Rating {
+    pub id: i32,
+    pub user_uid: String,
+    pub played: i64,
+    pub won: i64,
+    pub lost: i64,
+    pub draw: i64,
+    pub rating: f64,
+    pub deviation: f64,
+    pub volatility: f64,
+}
+
+impl Rating {
+    pub async fn for_uid(uid: &str, pool: &DbPool) -> Result<Self, Error> {
+        let conn = &mut get_conn(pool).await?;
+        ratings_table.filter(user_uid.eq(uid)).first(conn).await
+    }
+
+    pub async fn update(
+        rated: bool,
+        white_id: String,
+        black_id: String,
+        game_result: GameResult,
+        conn: &mut PooledConnection<'_, AsyncDieselConnectionManager<AsyncPgConnection>>,
+    ) -> Result<Option<(f64, f64)>, Error> {
+        let white_rating: Rating = ratings_table
+            .filter(user_uid.eq(white_id))
+            .first(conn)
+            .await?;
+        let black_rating: Rating = ratings_table
+            .filter(user_uid.eq(black_id))
+            .first(conn)
+            .await?;
+
+        match game_result {
+            GameResult::Draw => Rating::draw(rated, &white_rating, &black_rating, conn).await,
+            GameResult::Winner(color) => {
+                Rating::winner(rated, color, &white_rating, &black_rating, conn).await
+            }
+            GameResult::Unknown => unreachable!(
+                "This function should not be called when there's no concrete game result"
+            ),
+        }
+    }
+
+    fn calculate_glicko2(
+        white_rating: &Rating,
+        black_rating: &Rating,
+        game_result: GameResult,
+    ) -> (Glicko2Rating, Glicko2Rating, f64, f64) {
+        let white_glicko = Glicko2Rating {
+            rating: white_rating.rating,
+            deviation: white_rating.deviation,
+            volatility: white_rating.volatility,
+        };
+
+        let black_glicko = Glicko2Rating {
+            rating: black_rating.rating,
+            deviation: black_rating.deviation,
+            volatility: black_rating.volatility,
+        };
+
+        let config = Glicko2Config {
+            tau: 0.5,
+            ..Default::default()
+        };
+        let outcome = match game_result {
+            GameResult::Winner(winner) => {
+                if winner == Color::White {
+                    Outcomes::WIN
+                } else {
+                    Outcomes::LOSS
+                }
+            }
+            GameResult::Draw => Outcomes::DRAW,
+            GameResult::Unknown => unreachable!(),
+        };
+        let (white_glicko_new, black_glicko_new) =
+            glicko2(&white_glicko, &black_glicko, &outcome, &config);
+        (
+            white_glicko_new,
+            black_glicko_new,
+            white_glicko_new.rating - white_glicko.rating,
+            black_glicko_new.rating - black_glicko.rating,
+        )
+    }
+
+    async fn draw(
+        rated: bool,
+        white_rating: &Rating,
+        black_rating: &Rating,
+        conn: &mut PooledConnection<'_, AsyncDieselConnectionManager<AsyncPgConnection>>,
+    ) -> Result<Option<(f64, f64)>, Error> {
+        if rated {
+            let (white_glicko, black_glicko, white_rating_change, black_rating_change) =
+                Rating::calculate_glicko2(white_rating, black_rating, GameResult::Draw);
+            diesel::update(ratings::table.find(black_rating.id))
+                .set((
+                    played.eq(played + 1),
+                    draw.eq(draw + 1),
+                    rating.eq(black_glicko.rating),
+                    deviation.eq(black_glicko.deviation),
+                    volatility.eq(black_glicko.volatility),
+                ))
+                .execute(conn)
+                .await?;
+
+            diesel::update(ratings::table.find(white_rating.id))
+                .set((
+                    played.eq(played + 1),
+                    draw.eq(draw + 1),
+                    rating.eq(white_glicko.rating),
+                    deviation.eq(white_glicko.deviation),
+                    volatility.eq(white_glicko.volatility),
+                ))
+                .execute(conn)
+                .await?;
+            Ok(Some((white_rating_change, black_rating_change)))
+        } else {
+            diesel::update(ratings::table.find(black_rating.id))
+                .set((played.eq(played + 1), draw.eq(draw + 1)))
+                .execute(conn)
+                .await?;
+
+            diesel::update(ratings::table.find(white_rating.id))
+                .set((played.eq(played + 1), draw.eq(draw + 1)))
+                .execute(conn)
+                .await?;
+            Ok(None)
+        }
+    }
+
+    async fn winner(
+        rated: bool,
+        winner: Color,
+        white_rating: &Rating,
+        black_rating: &Rating,
+        conn: &mut PooledConnection<'_, AsyncDieselConnectionManager<AsyncPgConnection>>,
+    ) -> Result<Option<(f64, f64)>, Error> {
+        let (white_won, white_lost) = {
+            if winner == Color::White {
+                (1, 0)
+            } else {
+                (0, 1)
+            }
+        };
+
+        if rated {
+            let (white_glicko, black_glicko, white_rating_change, black_rating_change) =
+                Rating::calculate_glicko2(white_rating, black_rating, GameResult::Winner(winner));
+
+            diesel::update(ratings::table.find(white_rating.id))
+                .set((
+                    played.eq(played + 1),
+                    won.eq(won + white_won),
+                    lost.eq(lost + white_lost),
+                    rating.eq(white_glicko.rating),
+                    deviation.eq(white_glicko.deviation),
+                    volatility.eq(white_glicko.volatility),
+                ))
+                .execute(conn)
+                .await?;
+
+            diesel::update(ratings::table.find(black_rating.id))
+                .set((
+                    played.eq(played + 1),
+                    won.eq(won + white_lost),
+                    lost.eq(lost + white_won),
+                    rating.eq(black_glicko.rating),
+                    deviation.eq(black_glicko.deviation),
+                    volatility.eq(black_glicko.volatility),
+                ))
+                .execute(conn)
+                .await?;
+            Ok(Some((white_rating_change, black_rating_change)))
+        } else {
+            diesel::update(ratings::table.find(white_rating.id))
+                .set((
+                    played.eq(played + 1),
+                    won.eq(won + white_won),
+                    lost.eq(lost + white_lost),
+                ))
+                .execute(conn)
+                .await?;
+
+            diesel::update(ratings::table.find(black_rating.id))
+                .set((
+                    played.eq(played + 1),
+                    won.eq(won + white_lost),
+                    lost.eq(lost + white_won),
+                ))
+                .execute(conn)
+                .await?;
+            Ok(None)
+        }
+    }
+}

--- a/db/src/models/user.rs
+++ b/db/src/models/user.rs
@@ -1,0 +1,111 @@
+use crate::{
+    error::DbError, models::{game::Game, game_user::GameUser, rating::NewRating},
+    schema::{games, ratings, users, users::dsl::users as users_table},
+    get_conn, DbPool
+};
+use diesel::{
+    query_dsl::BelongingToDsl, result::Error, Identifiable, Insertable, QueryDsl, Queryable,
+    SelectableHelper,
+};
+use diesel_async::{AsyncConnection, RunQueryDsl, scoped_futures::ScopedFutureExt};
+use serde::{Deserialize, Serialize};
+
+const MAX_USERNAME_LENGTH: usize = 40;
+const VALID_USERNAME_CHARS: &str = "-_";
+
+fn valid_uid_char(c: char) -> bool {
+    c.is_ascii_alphanumeric()
+}
+
+fn validate_uid(uid: &str) -> Result<(), DbError> {
+    if !uid.chars().all(valid_uid_char) {
+        return Err(DbError::UserInputError {
+            field: "uid".into(),
+            reason: "invalid characters".into(),
+        });
+    }
+    Ok(())
+}
+
+fn valid_username_char(c: char) -> bool {
+    c.is_ascii_alphanumeric() || VALID_USERNAME_CHARS.contains(c)
+}
+
+fn validate_username(username: &str) -> Result<(), DbError> {
+    if !username.chars().all(valid_username_char) {
+        let reason = format!("invalid username characters: {:?}", username);
+        return Err(DbError::UserInputError {
+            field: "username".into(),
+            reason,
+        });
+    } else if username.len() > MAX_USERNAME_LENGTH {
+        let reason = format!("username must be <= {} chars", MAX_USERNAME_LENGTH);
+        return Err(DbError::UserInputError {
+            field: "username".into(),
+            reason,
+        });
+    }
+    Ok(())
+}
+
+#[derive(Queryable, Identifiable, Insertable, Serialize, Deserialize, Debug, Clone)]
+#[diesel(primary_key(uid))]
+pub struct User {
+    pub uid: String,
+    pub username: String,
+    pub password: String,
+    pub token: String,
+}
+
+impl User {
+    pub fn new(uid: &str, username: &str, password: &str, token: &str) -> Result<User, DbError> {
+        validate_uid(uid)?;
+        validate_username(username)?;
+        Ok(User {
+            uid: uid.into(),
+            username: username.into(),
+            password: password.into(),
+            token: token.into(),
+        })
+    }
+
+    pub async fn find_by_uid(uid: &str, pool: &DbPool) -> Result<User, Error> {
+        let conn = &mut get_conn(pool).await?;
+        users_table.find(uid).first(conn).await
+    }
+
+    pub async fn insert(&self, pool: &DbPool) -> Result<(), Error> {
+        let connection = &mut get_conn(pool).await?;
+        connection
+            .transaction::<_, diesel::result::Error, _>(|conn| {
+                async move {
+                    self.insert_into(users::table).execute(conn).await?;
+                    let new_rating = NewRating::for_uid(&self.uid);
+                    diesel::insert_into(ratings::table)
+                        .values(&new_rating)
+                        .execute(conn)
+                        .await?;
+                    Ok(())
+                }
+                .scope_boxed()
+            })
+            .await?;
+        Ok(())
+    }
+
+    pub async fn delete(&self, pool: &DbPool) -> Result<usize, Error> {
+        let conn = &mut get_conn(pool).await?;
+        diesel::delete(users_table.find(&self.uid))
+            .execute(conn)
+            .await
+    }
+
+    pub async fn get_games(&self, pool: &DbPool) -> Result<Vec<Game>, Error> {
+        let conn = &mut get_conn(pool).await?;
+        GameUser::belonging_to(self)
+            .inner_join(games::table)
+            .select(Game::as_select())
+            .get_results(conn)
+            .await
+    }
+}

--- a/db/src/schema.rs
+++ b/db/src/schema.rs
@@ -1,0 +1,76 @@
+// @generated automatically by Diesel CLI.
+
+diesel::table! {
+    challenges (id) {
+        id -> Uuid,
+        challenger_uid -> Text,
+        game_type -> Text,
+        rated -> Bool,
+        public -> Bool,
+        tournament_queen_rule -> Bool,
+        color_choice -> Text,
+        created_at -> Timestamptz,
+    }
+}
+
+diesel::table! {
+    games (id) {
+        id -> Int4,
+        black_uid -> Text,
+        game_status -> Text,
+        game_type -> Text,
+        history -> Text,
+        game_control_history -> Text,
+        rated -> Bool,
+        tournament_queen_rule -> Bool,
+        turn -> Int4,
+        white_uid -> Text,
+        white_rating -> Nullable<Float8>,
+        black_rating -> Nullable<Float8>,
+        white_rating_change -> Nullable<Float8>,
+        black_rating_change -> Nullable<Float8>,
+    }
+}
+
+diesel::table! {
+    games_users (game_id, user_uid) {
+        game_id -> Int4,
+        user_uid -> Text,
+    }
+}
+
+diesel::table! {
+    ratings (id) {
+        id -> Int4,
+        user_uid -> Text,
+        played -> Int8,
+        won -> Int8,
+        lost -> Int8,
+        draw -> Int8,
+        rating -> Float8,
+        deviation -> Float8,
+        volatility -> Float8,
+    }
+}
+
+diesel::table! {
+    users (uid) {
+        uid -> Text,
+        username -> Text,
+        password -> Text,
+        token -> Text,
+    }
+}
+
+diesel::joinable!(challenges -> users (challenger_uid));
+diesel::joinable!(games_users -> games (game_id));
+diesel::joinable!(games_users -> users (user_uid));
+diesel::joinable!(ratings -> users (user_uid));
+
+diesel::allow_tables_to_appear_in_same_query!(
+    challenges,
+    games,
+    games_users,
+    ratings,
+    users,
+);

--- a/server/.env
+++ b/server/.env
@@ -1,0 +1,2 @@
+DATABASE_URL="postgres://hive-dev@localhost:/hive-local"
+TEST_DATABASE_URL="postgres://hive-dev@localhost:/hive-test"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 app = { path = "../app", default-features = false, features = ["ssr"] }
+db = { path = "../db" }
 leptos = { workspace = true, features = [ "ssr" ]}
 leptos_actix.workspace = true
 
@@ -20,3 +21,4 @@ tokio.workspace = true
 log.workspace = true
 uuid.workspace = true
 serde = { workspace = true, features = ["derive"] }
+

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -5,9 +5,10 @@ use actix::Actor;
 use actix_files::Files;
 use actix_web::*;
 use app::*;
+
+use db_lib::get_pool;
 use leptos::*;
 use leptos_actix::{generate_route_list, LeptosRoutes};
-
 
 mod lobby;
 mod messages;
@@ -23,11 +24,19 @@ async fn main() -> std::io::Result<()> {
     let routes = generate_route_list(|| view! { <App/> });
     let chat_server = Lobby::default().start();
 
+    // Todo fixme
+    // let config = DbConfig::from_env().expect("Failed to load config from env");
+
+    let database_url = "postgres://hive-dev@localhost:/hive-local";
+    let pool = get_pool(database_url).await.expect("Failed to get pool");
+
     HttpServer::new(move || {
         let leptos_options = &conf.leptos_options;
         let site_root = &leptos_options.site_root;
 
         App::new()
+            .app_data(actix_web::web::Data::new(pool.clone()))
+            .app_data(actix_web::web::Data::new(chat_server.clone()))
             .route("/api/{tail:.*}", leptos_actix::handle_server_fns())
             // serve JS/WASM/CSS from `pkg`
             .service(Files::new("/pkg", format!("{site_root}/pkg")))
@@ -36,7 +45,6 @@ async fn main() -> std::io::Result<()> {
             // serve the favicon from /favicon.ico
             .service(favicon)
             .service(start_connection::start_connection)
-            .data(chat_server.clone())
             .leptos_routes(
                 leptos_options.to_owned(),
                 routes.to_owned(),


### PR DESCRIPTION
Adds a new crate `db` with migrations and models for `User`, `Game`, `Challenge`, `GameUser` and `Rating`.
Adds helper functions to access the `pool`ed DB from server functions.
Adds example for `User::get` in `functions/user/get.rs`. 