### PR TITLE
Navigation controller

### DIFF
--- a/apis/src/app.rs
+++ b/apis/src/app.rs
@@ -6,8 +6,9 @@ use crate::{
     },
     providers::{
         auth_context::provide_auth, challenges::provide_challenges,
-        color_scheme::provide_color_scheme, game_state::provide_game_state,
-        online_users::provide_users, timer::provide_timer, web_socket::provide_websocket,
+        color_scheme::provide_color_scheme, game_state::provide_game_state, games::provide_games,
+        navigation_controller::provide_navigation_controller, online_users::provide_users,
+        timer::provide_timer, web_socket::provide_websocket,
     },
 };
 use leptos::*;
@@ -21,8 +22,10 @@ pub fn App() -> impl IntoView {
     provide_meta_context();
     provide_game_state();
     provide_challenges();
+    provide_games();
     provide_users();
     provide_timer();
+    provide_navigation_controller();
     let url = "/ws/";
     provide_websocket(url);
     provide_auth();

--- a/apis/src/common/server_result.rs
+++ b/apis/src/common/server_result.rs
@@ -56,7 +56,7 @@ pub enum ServerMessage {
         game_id: String,
         message: String,
     },
-    GameActionNotification(Vec<String>),
+    GameActionNotification(Vec<GameResponse>),
     GameUpdate(GameActionResponse),
     GameTimeoutCheck(GameResponse),
     GameNew(GameResponse),

--- a/apis/src/components/atoms/next_game_button.rs
+++ b/apis/src/components/atoms/next_game_button.rs
@@ -1,50 +1,44 @@
-use crate::providers::game_state::GameStateSignal;
-use lazy_static::lazy_static;
-use leptos::*;
+use crate::providers::{
+    game_state::GameStateSignal, games::GamesSignal,
+    navigation_controller::NavigationControllerSignal,
+};
+use leptos::{logging::log, *};
 use leptos_meta::Title;
-use leptos_router::RouterContext;
-use regex::Regex;
-lazy_static! {
-    static ref NANOID: Regex =
-        Regex::new(r"/game/(?<nanoid>.*)").expect("This regex should compile");
-}
 
 #[component]
 pub fn NextGameButton() -> impl IntoView {
     let navigate = leptos_router::use_navigate();
-    let game_state_signal = expect_context::<GameStateSignal>();
-
+    let mut games = expect_context::<GamesSignal>();
+    let navigation_controller = expect_context::<NavigationControllerSignal>();
     let next_games = move || {
-        let mut games = game_state_signal.signal.get().next_games;
-        let router = expect_context::<RouterContext>();
-        if let Some(caps) = NANOID.captures(&router.pathname().get_untracked()) {
-            let nanoid = caps.name("nanoid").map_or("", |m| m.as_str());
-            games.retain(|game| *game != nanoid);
+        let mut next_games = games.signal.get().next_games;
+        log!("Games in ngb: {:?}", next_games);
+        if let Some(nanoid) = navigation_controller.signal.get().nanoid {
+            log!("Nanoid in ngb: {:?}", nanoid);
+            next_games.retain(|g| *g != nanoid);
         }
-        games
+        log!("Games without nanoid: {:?}", next_games);
+        next_games
     };
-
     let color = move || match next_games().len() {
         0 => "hidden",
         _ => "bg-red-700 duration-300 hover:bg-red-600 text-white rounded-md px-2 py-1 m-2",
     };
-
     let title_text = move || match next_games().len() {
         0 => String::from("HiveGame.com"),
         i => format!("({}) HiveGame.com", i),
     };
-
     let text = move || match next_games().len() {
         0 => String::new(),
         1 => String::from("Next"),
         i => format!("Next ({})", i),
     };
-
     let onclick = move |_| {
-        let mut games = next_games();
-        if let Some(game) = games.pop() {
-            // TODO: this needs to happen when a move has successfully been played
-            //game_state_signal.set_next_games(games);
+        let next_games = next_games();
+        if let Some(game) = next_games.first() {
+            let mut game_state = expect_context::<GameStateSignal>();
+            game_state.full_reset();
+            games.visit_game(game.to_owned());
             navigate(&format!("/game/{}", game), Default::default());
         } else {
             navigate("/", Default::default());

--- a/apis/src/components/layouts/base_layout.rs
+++ b/apis/src/components/layouts/base_layout.rs
@@ -1,8 +1,17 @@
-use leptos::*;
-use leptos_meta::*;
-
 use crate::components::organisms::header::Header;
 use crate::providers::color_scheme::ColorScheme;
+use crate::providers::navigation_controller::NavigationControllerSignal;
+use lazy_static::lazy_static;
+
+use leptos::*;
+use leptos_meta::*;
+use leptos_router::use_location;
+use regex::Regex;
+
+lazy_static! {
+    static ref NANOID: Regex =
+        Regex::new(r"/game/(?<nanoid>.*)").expect("This regex should compile");
+}
 
 #[component]
 pub fn BaseLayout(children: Children) -> impl IntoView {
@@ -14,6 +23,18 @@ pub fn BaseLayout(children: Children) -> impl IntoView {
             "light".to_string()
         }
     };
+
+    create_effect(move |_| {
+        let location = use_location();
+        let mut navi = expect_context::<NavigationControllerSignal>();
+        let pathname = (location.pathname)();
+        let nanoid = if let Some(caps) = NANOID.captures(&pathname) {
+            caps.name("nanoid").map(|m| m.as_str().to_string())
+        } else {
+            None
+        };
+        navi.update_nanoid(nanoid);
+    });
 
     view! {
         <Meta name="color-scheme" content=color_scheme_meta/>

--- a/apis/src/components/molecules/challenge_row.rs
+++ b/apis/src/components/molecules/challenge_row.rs
@@ -161,9 +161,7 @@ pub fn ChallengeRow(challenge: StoredValue<ChallengeResponse>, single: bool) -> 
                             match (auth_context.user)() {
                                 Some(Ok(Some(_))) => {
                                     let mut game_state = expect_context::<GameStateSignal>();
-                                    let games = game_state.signal.get().next_games;
                                     game_state.full_reset();
-                                    game_state.signal.update(|s| s.next_games = games);
                                     ApiRequests::new().challenge_accept(challenge().nanoid);
                                 }
                                 _ => {

--- a/apis/src/components/molecules/rating_and_change.rs
+++ b/apis/src/components/molecules/rating_and_change.rs
@@ -1,5 +1,5 @@
+use crate::providers::game_state::GameStateSignal;
 use crate::responses::game::GameResponse;
-use crate::{functions::games::get::get_game_from_nanoid, providers::game_state::GameStateSignal};
 use hive_lib::color::Color;
 use leptos::*;
 use std::cmp::Ordering;
@@ -49,39 +49,16 @@ pub fn RatingAndChangeDynamic(
     #[prop(optional)] extend_tw_classes: &'static str,
     side: Color,
 ) -> impl IntoView {
-    let game_state_signal = expect_context::<GameStateSignal>();
-    let game_id = move || game_state_signal.signal.get_untracked().game_id;
+    let game_state = expect_context::<GameStateSignal>();
+    let game = move || game_state.signal.get().game_response;
     view! {
-        <Show when=move || {
-            game_id().is_some()
-        }>
-            {move || {
-                let game = Resource::once(move || get_game_from_nanoid(
-                    (game_id().expect("Some game_id"))(),
-                ));
-                view! {
-                    <Transition>
-                        {move || {
-                            game()
-                                .map(|data| match data {
-                                    Err(_) => view! { <pre>"Error"</pre> }.into_view(),
-                                    Ok(game) => {
-                                        view! {
-                                            <RatingAndChange
-                                                extend_tw_classes=extend_tw_classes
-                                                game=game
-                                                side=side
-                                            />
-                                        }
-                                            .into_view()
-                                    }
-                                })
-                        }}
-
-                    </Transition>
-                }
-            }}
-
-        </Show>
+        {move || {
+            game()
+                .map(|game| {
+                    view! {
+                        <RatingAndChange extend_tw_classes=extend_tw_classes game=game side=side/>
+                    }
+                })
+        }}
     }
 }

--- a/apis/src/components/molecules/user_with_rating.rs
+++ b/apis/src/components/molecules/user_with_rating.rs
@@ -7,33 +7,41 @@ use crate::{
         molecules::rating_and_change::RatingAndChangeDynamic,
     },
     providers::game_state::GameStateSignal,
-    responses::user::UserResponse,
 };
 
 #[component]
-pub fn UserWithRating(
-    player: StoredValue<UserResponse>,
-    side: Color,
-    #[prop(optional)] text_color: &'static str,
-) -> impl IntoView {
+pub fn UserWithRating(side: Color, #[prop(optional)] text_color: &'static str) -> impl IntoView {
     let game_state = expect_context::<GameStateSignal>();
+    let player = move || match side {
+        Color::White => game_state
+            .signal
+            .get()
+            .game_response
+            .map(|g| g.white_player),
+        Color::Black => game_state
+            .signal
+            .get()
+            .game_response
+            .map(|g| g.black_player),
+    };
     let is_finished = create_memo(move |_| {
         matches!(
             (game_state.signal)().state.game_status,
             GameStatus::Finished(_)
         )
     });
+    let username = move || player().map_or(String::new(), |p| p.username);
+    let rating = move || player().map_or(String::new(), |p| p.rating.to_string());
     view! {
         <div class="flex items-center flex-col justify-center">
             <div class="flex justify-center">
-                <StatusIndicator username=player().username/>
-                <ProfileLink username=player().username extend_tw_classes=text_color/>
+                {move || view! { <StatusIndicator username=username()/> }}
+                {move || view! { <ProfileLink username=username() extend_tw_classes=text_color/> }}
             </div>
-
             <Show
                 when=is_finished
                 fallback=move || {
-                    view! { <p class=format!("{text_color}")>{player().rating}</p> }
+                    view! { <p class=format!("{text_color}")>{rating()}</p> }
                 }
             >
 

--- a/apis/src/pages/play.rs
+++ b/apis/src/pages/play.rs
@@ -9,27 +9,11 @@ use crate::{
             side_board::SideboardTabs,
         },
     },
-    functions::games::get::get_game_from_nanoid,
     providers::{auth_context::AuthContext, game_state::GameStateSignal},
-    responses::user::UserResponse,
 };
 use hive_lib::{color::Color, position::Position};
 use leptos::*;
-use leptos_router::*;
 use leptos_use::use_media_query;
-
-#[derive(Params, PartialEq, Eq)]
-struct PlayParams {
-    nanoid: String,
-}
-
-#[derive(Clone)]
-struct PlayersAndColors {
-    top_player: StoredValue<UserResponse>,
-    top_player_color: Color,
-    bottom_player: StoredValue<UserResponse>,
-    bottom_player_color: Color,
-}
 
 #[derive(Clone)]
 pub struct TargetStack(pub RwSignal<Option<Position>>);
@@ -37,212 +21,122 @@ pub struct TargetStack(pub RwSignal<Option<Position>>);
 #[component]
 pub fn Play(#[prop(optional)] extend_tw_classes: &'static str) -> impl IntoView {
     provide_context(TargetStack(RwSignal::new(None)));
-    let params = use_params::<PlayParams>();
     let auth_context = expect_context::<AuthContext>();
     let user = move || match (auth_context.user)() {
         Some(Ok(Some(user))) => Some(user),
         _ => None,
     };
 
-    let nanoid = move || {
-        params.with(|params| {
-            params
-                .as_ref()
-                .map(|params| params.nanoid.clone())
-                .unwrap_or_default()
+    let is_tall = use_media_query("(min-height: 100vw)");
+    let nav_buttons_style = "flex place-items-center justify-center hover:bg-green-400 dark:hover:bg-green-500 duration-300 my-1 h-6 rounded-md border-cyan-500 border-2 drop-shadow-lg";
+    let game_state = expect_context::<GameStateSignal>();
+    let parent_container_style = move || {
+        if is_tall() {
+            "flex flex-col"
+        } else {
+            "grid grid-cols-board-xs sm:grid-cols-board-sm lg:grid-cols-board-lg xxl:grid-cols-board-xxl grid-rows-6 pr-1"
+        }
+    };
+    let show_buttons = move || {
+        user().map_or(false, |user| {
+            let game_state = game_state.signal.get();
+            Some(user.id) == game_state.black_id || Some(user.id) == game_state.white_id
         })
     };
+    let player_is_black = create_memo(move |_| {
+        user().map_or(false, |user| {
+            let game_state = game_state.signal.get();
+            Some(user.id) == game_state.black_id
+        })
+    });
+    let go_to_game = Callback::new(move |()| {
+        let mut game_state = expect_context::<GameStateSignal>();
+        if game_state.signal.get_untracked().is_last_turn() {
+            game_state.view_game();
+        }
+    });
+    let bottom_color = move || {
+        if player_is_black() {
+            Color::Black
+        } else {
+            Color::White
+        }
+    };
+    let top_color = move || bottom_color().opposite_color();
 
-    let is_tall = use_media_query("(min-height: 100vw)");
-    let game = create_blocking_resource(nanoid, move |_| get_game_from_nanoid(nanoid()));
-    let nav_buttons_style =
-        "flex place-items-center justify-center hover:bg-green-400 dark:hover:bg-green-500 duration-300 my-1 h-6 rounded-md border-cyan-500 border-2 drop-shadow-lg";
-
-    // WARN: THIS IS A MOVE be very careful with what you do with signals!
     view! {
-        <Transition>
-            {move || {
-                game()
-                    .map(|data| match data {
-                        Err(_) => view! { <pre>"Page not found"</pre> }.into_view(),
-                        Ok(game) => {
-                            let parent_container_style = if is_tall() {
-                                "flex flex-col"
-                            } else {
-                                "grid grid-cols-board-xs sm:grid-cols-board-sm lg:grid-cols-board-lg xxl:grid-cols-board-xxl grid-rows-6 pr-1"
-                            };
-                            let game = store_value(game);
-                            let mut game_state = expect_context::<GameStateSignal>();
-                            game_state.set_game_id(store_value(nanoid()));
-                            let white_player = store_value(game().white_player);
-                            let black_player = store_value(game().black_player);
-                            let state = game().create_state();
-                            game_state.set_state(state, black_player().uid, white_player().uid);
-                            game_state.join();
-                            let show_buttons = move || {
-                                user()
-                                    .map_or(
-                                        false,
-                                        |user| {
-                                            let game_state = game_state.signal.get();
-                                            Some(user.id) == game_state.black_id
-                                                || Some(user.id) == game_state.white_id
-                                        },
-                                    )
-                            };
-                            let player_is_black = create_memo(move |_| {
-                                user()
-                                    .map_or(
-                                        false,
-                                        |user| {
-                                            let game_state = game_state.signal.get();
-                                            Some(user.id) == game_state.black_id
-                                        },
-                                    )
-                            });
-                            let players = players_and_colors(
-                                player_is_black(),
-                                white_player,
-                                black_player,
-                            );
-                            let go_to_game = Callback::new(move |()| {
-                                let mut game_state = expect_context::<GameStateSignal>();
-                                if game_state.signal.get_untracked().is_last_turn() {
-                                    game_state.view_game();
-                                }
-                            });
-                            view! {
-                                <div class=move || {
-                                    format!(
-                                        "max-h-[100dvh] min-h-[100dvh] pt-10 {parent_container_style} {extend_tw_classes}",
-                                    )
-                                }>
-                                    <Show
-                                        when=is_tall
-                                        fallback=move || {
-                                            view! {
-                                                <Board/>
-                                                <div class="grid col-start-9 col-span-2 row-span-full grid-cols-2 grid-rows-6">
-                                                    <DisplayTimer
-                                                        side=players.top_player_color
-                                                        placement=Placement::Top
-                                                        player=players.top_player
-                                                        vertical=false
-                                                    />
-                                                    <SideboardTabs player_is_black=player_is_black/>
-                                                    <DisplayTimer
-                                                        side=players.bottom_player_color
-                                                        placement=Placement::Bottom
-                                                        player=players.bottom_player
-                                                        vertical=false
-                                                    />
-                                                </div>
-                                            }
-                                        }
-                                    >
+        <div class=move || {
+            format!(
+                "max-h-[100dvh] min-h-[100dvh] pt-10 {} {extend_tw_classes}",
+                parent_container_style(),
+            )
+        }>
+            <Show
+                when=is_tall
+                fallback=move || {
+                    view! {
+                        <Board/>
+                        <div class="grid col-start-9 col-span-2 row-span-full grid-cols-2 grid-rows-6">
+                            <DisplayTimer placement=Placement::Top vertical=false/>
+                            <SideboardTabs player_is_black=player_is_black/>
+                            <DisplayTimer placement=Placement::Bottom vertical=false/>
+                        </div>
+                    }
+                }
+            >
 
-                                        <div class="flex flex-col flex-grow h-full min-h-0">
-                                            <div class="flex flex-col shrink flex-grow">
-                                                <div class="flex justify-between shrink">
+                <div class="flex flex-col flex-grow h-full min-h-0">
+                    <div class="flex flex-col shrink flex-grow">
+                        <div class="flex justify-between shrink">
 
-                                                    <Show when=show_buttons>
-                                                        <ControlButtons/>
-                                                    </Show>
-                                                </div>
-                                                <div class="flex max-h-16 justify-between h-full">
-                                                    <Reserve
-                                                        alignment=Alignment::SingleRow
-                                                        color=players.top_player_color
-                                                    />
-                                                    <DisplayTimer
-                                                        side=players.top_player_color
-                                                        player=players.top_player
-                                                        vertical=true
-                                                    />
-                                                </div>
-                                                <div class="ml-2 flex gap-1">
-                                                    <UserWithRating
-                                                        player=players.top_player
-                                                        side=players.top_player_color
-                                                    />
-                                                </div>
+                            <Show when=show_buttons>
+                                <ControlButtons/>
+                            </Show>
+                        </div>
+                        <div class="flex max-h-16 justify-between h-full">
+                            <Reserve alignment=Alignment::SingleRow color=top_color()/>
+                            <DisplayTimer vertical=true/>
+                        </div>
+                        <div class="ml-2 flex gap-1">
+                            <UserWithRating side=top_color()/>
+                        </div>
 
-                                            </div>
-                                            <Board overwrite_tw_classes="flex grow min-h-0"/>
-                                            <div class="flex flex-col shrink flex-grow">
-                                                <div class="ml-2 flex gap-1">
-                                                    <UserWithRating
-                                                        player=players.bottom_player
-                                                        side=players.bottom_player_color
-                                                    />
-                                                </div>
-                                                <div class="flex max-h-16 justify-between h-full">
-                                                    <Reserve
-                                                        alignment=Alignment::SingleRow
-                                                        color=players.bottom_player_color
-                                                    />
+                    </div>
+                    <Board overwrite_tw_classes="flex grow min-h-0"/>
+                    <div class="flex flex-col shrink flex-grow">
+                        <div class="ml-2 flex gap-1">
+                            <UserWithRating side=bottom_color()/>
+                        </div>
+                        <div class="flex max-h-16 justify-between h-full">
+                            <Reserve alignment=Alignment::SingleRow color=bottom_color()/>
+                            <DisplayTimer vertical=true/>
+                        </div>
+                        <div class="grid grid-cols-4 gap-8">
+                            <HistoryButton
+                                nav_buttons_style=nav_buttons_style
+                                action=HistoryNavigation::First
+                            />
 
-                                                    <DisplayTimer
-                                                        side=players.bottom_player_color
-                                                        player=players.bottom_player
-                                                        vertical=true
-                                                    />
-                                                </div>
-                                                <div class="grid grid-cols-4 gap-8">
-                                                    <HistoryButton
-                                                        nav_buttons_style=nav_buttons_style
-                                                        action=HistoryNavigation::First
-                                                    />
+                            <HistoryButton
+                                nav_buttons_style=nav_buttons_style
+                                action=HistoryNavigation::Previous
+                            />
 
-                                                    <HistoryButton
-                                                        nav_buttons_style=nav_buttons_style
-                                                        action=HistoryNavigation::Previous
-                                                    />
+                            <HistoryButton
+                                nav_buttons_style=nav_buttons_style
+                                action=HistoryNavigation::Next
+                                post_action=go_to_game
+                            />
 
-                                                    <HistoryButton
-                                                        nav_buttons_style=nav_buttons_style
-                                                        action=HistoryNavigation::Next
-                                                        post_action=go_to_game
-                                                    />
+                            <HistoryButton
+                                nav_buttons_style=nav_buttons_style
+                                action=HistoryNavigation::MobileLast
+                            />
 
-                                                    <HistoryButton
-                                                        nav_buttons_style=nav_buttons_style
-                                                        action=HistoryNavigation::MobileLast
-                                                    />
-
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </Show>
-                                </div>
-                            }
-                                .into_view()
-                        }
-                    })
-            }}
-
-        </Transition>
-    }
-}
-
-fn players_and_colors(
-    player_is_black: bool,
-    white_player: StoredValue<UserResponse>,
-    black_player: StoredValue<UserResponse>,
-) -> PlayersAndColors {
-    if player_is_black {
-        PlayersAndColors {
-            top_player: white_player,
-            top_player_color: Color::White,
-            bottom_player: black_player,
-            bottom_player_color: Color::Black,
-        }
-    } else {
-        PlayersAndColors {
-            top_player: black_player,
-            top_player_color: Color::Black,
-            bottom_player: white_player,
-            bottom_player_color: Color::White,
-        }
+                        </div>
+                    </div>
+                </div>
+            </Show>
+        </div>
     }
 }

--- a/apis/src/providers/api_requests.rs
+++ b/apis/src/providers/api_requests.rs
@@ -5,6 +5,8 @@ use crate::providers::web_socket::WebsocketContext;
 use hive_lib::{game_control::GameControl, turn::Turn};
 use leptos::*;
 
+use super::games::GamesSignal;
+
 #[derive(Clone)]
 pub struct ApiRequests {
     websocket: WebsocketContext,
@@ -24,11 +26,13 @@ impl ApiRequests {
 
     pub fn turn(&self, game_id: String, turn: Turn) {
         let msg = ClientRequest::Game {
-            id: game_id,
+            id: game_id.to_owned(),
             action: GameAction::Move(turn),
         };
         self.websocket
             .send(&serde_json::to_string(&msg).expect("Serde_json::to_string failed"));
+        let mut games = expect_context::<GamesSignal>();
+        games.games_remove(&game_id);
     }
 
     pub fn game_control(&self, game_id: String, gc: GameControl) {

--- a/apis/src/providers/games.rs
+++ b/apis/src/providers/games.rs
@@ -1,0 +1,113 @@
+use super::auth_context::AuthContext;
+use crate::responses::game::GameResponse;
+use hive_lib::{color::Color, game_control::GameControl};
+use leptos::*;
+use std::collections::HashMap;
+
+#[derive(Clone, Debug, Copy)]
+pub struct GamesSignal {
+    pub signal: RwSignal<GamesState>,
+}
+
+impl Default for GamesSignal {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl GamesSignal {
+    pub fn new() -> Self {
+        Self {
+            signal: create_rw_signal(GamesState::new()),
+        }
+    }
+
+    fn update_next_games(&mut self) {
+        let auth_context = expect_context::<AuthContext>();
+        if let Some(Ok(Some(user))) = untrack(auth_context.user) {
+            self.signal.update(|s| {
+                s.next_games = s
+                    .games
+                    .iter()
+                    .filter_map(|(nanoid, game)| {
+                        let not_player_color = if game.black_player.uid == user.id {
+                            Color::White
+                        } else {
+                            Color::Black
+                        };
+                        let gc = game.game_control_history.last().map(|(_turn, gc)| gc);
+                        let unanswered_gc = match gc {
+                            Some(GameControl::DrawOffer(color))
+                            | Some(GameControl::TakebackRequest(color)) => {
+                                *color == not_player_color
+                            }
+                            _ => false,
+                        };
+                        if !game.finished && (game.current_player_id == user.id || unanswered_gc) {
+                            Some(nanoid.to_owned())
+                        } else {
+                            None
+                        }
+                    })
+                    .collect::<Vec<String>>()
+            });
+        };
+    }
+
+    pub fn visit_game(&mut self, game_id: String) {
+        self.signal.update(|s| {
+            let mut games = s.next_games.clone();
+            games.retain(|g| *g != game_id);
+            games.push(game_id);
+            s.next_games = games;
+        });
+    }
+
+    pub fn games_add(&mut self, game: GameResponse) {
+        self.signal.update_untracked(|s| {
+            s.games.insert(game.nanoid.to_owned(), game);
+        });
+        self.update_next_games();
+    }
+
+    pub fn games_remove(&mut self, game_id: &str) {
+        self.signal.update_untracked(|s| {
+            s.games.remove(game_id);
+        });
+        self.update_next_games();
+    }
+
+    pub fn games_set(&mut self, games: Vec<GameResponse>) {
+        for game in games {
+            self.signal.update_untracked(|s| {
+                s.games.insert(game.nanoid.to_owned(), game);
+            });
+        }
+        self.update_next_games();
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct GamesState {
+    pub games: HashMap<String, GameResponse>,
+    pub next_games: Vec<String>,
+}
+
+impl GamesState {
+    pub fn new() -> Self {
+        Self {
+            next_games: Vec::new(),
+            games: HashMap::new(),
+        }
+    }
+}
+
+impl Default for GamesState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub fn provide_games() {
+    provide_context(GamesSignal::new())
+}

--- a/apis/src/providers/mod.rs
+++ b/apis/src/providers/mod.rs
@@ -3,6 +3,8 @@ pub mod auth_context;
 pub mod challenges;
 pub mod color_scheme;
 pub mod game_state;
+pub mod games;
+pub mod navigation_controller;
 pub mod online_users;
 pub mod timer;
 pub mod web_socket;

--- a/apis/src/providers/navigation_controller.rs
+++ b/apis/src/providers/navigation_controller.rs
@@ -1,0 +1,60 @@
+use lazy_static::lazy_static;
+use leptos::*;
+use regex::Regex;
+
+use crate::providers::{api_requests::ApiRequests, game_state::GameStateSignal};
+
+lazy_static! {
+    static ref NANOID: Regex =
+        Regex::new(r"/game/(?<nanoid>.*)").expect("This regex should compile");
+}
+
+#[derive(Clone, Debug, Copy)]
+pub struct NavigationControllerSignal {
+    pub signal: RwSignal<NavigationControllerState>,
+}
+
+impl Default for NavigationControllerSignal {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl NavigationControllerSignal {
+    pub fn new() -> Self {
+        Self {
+            signal: create_rw_signal(NavigationControllerState::new()),
+        }
+    }
+
+    pub fn update_nanoid(&mut self, nanoid: Option<String>) {
+        self.signal.update(|s| s.nanoid = nanoid.to_owned());
+        let api = ApiRequests::new();
+        if let Some(game_id) = nanoid {
+            let mut game_state = expect_context::<GameStateSignal>();
+            game_state.set_game_id(game_id.to_owned());
+            api.join(game_id.to_owned());
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct NavigationControllerState {
+    pub nanoid: Option<String>,
+}
+
+impl NavigationControllerState {
+    pub fn new() -> Self {
+        Self { nanoid: None }
+    }
+}
+
+impl Default for NavigationControllerState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub fn provide_navigation_controller() {
+    provide_context(NavigationControllerSignal::new())
+}

--- a/apis/src/responses/game.rs
+++ b/apis/src/responses/game.rs
@@ -12,6 +12,7 @@ use uuid::Uuid;
 pub struct GameResponse {
     pub game_id: Uuid,
     pub nanoid: String,
+    pub current_player_id: Uuid,
     pub turn: usize,
     pub finished: bool,
     pub game_status: GameStatus,
@@ -107,6 +108,7 @@ impl GameResponse {
             game_id: game.id,
             nanoid: game.nanoid.clone(),
             game_status: GameStatus::from_str(&game.game_status)?,
+            current_player_id: game.current_player_id,
             finished: game.finished,
             game_type: GameType::from_str(&game.game_type)?,
             tournament_queen_rule: game.tournament_queen_rule,

--- a/apis/src/websockets/turn_handler.rs
+++ b/apis/src/websockets/turn_handler.rs
@@ -82,15 +82,16 @@ impl TurnHandler {
                 .await?;
         }
         let current_user = User::find_by_uuid(&game.current_player_id, &self.pool).await?;
-        let game_ids = current_user
+        let games = current_user
             .get_games_with_notifications(&self.pool)
-            .await?
-            .into_iter()
-            .map(|game| game.nanoid)
-            .collect();
+            .await?;
+        let mut game_responses = Vec::new();
+        for game in games {
+            game_responses.push(GameResponse::new_from_db(&game, &self.pool).await?);
+        }
         messages.push(InternalServerMessage {
             destination: MessageDestination::Direct(game.current_player_id),
-            message: ServerMessage::GameActionNotification(game_ids),
+            message: ServerMessage::GameActionNotification(game_responses),
         });
         messages.push(InternalServerMessage {
             destination: MessageDestination::Game(self.game.nanoid.clone()),

--- a/db/src/db_error.rs
+++ b/db/src/db_error.rs
@@ -11,6 +11,8 @@ pub enum DbError {
     NotFound { reason: String },
     #[error("Time not present")]
     TimeNotFound { reason: String },
+    #[error("Game is over")]
+    GameIsOver,
 }
 
 impl From<diesel::result::Error> for DbError {


### PR DESCRIPTION
The motivation behind his PR is to get rid of the last non websocket requests: Namely when navigating to `/play/game_id` and getting the ELO after a game has ended. This is achieved by implementing a navigation controller which keeps track of the pathname and if the pathname contains a `game_id` it loads the game via the websocket.
While implementing this a couple of other things were fixed/updated:
- resign and draw work again for untimed games
- users are forwarded from the landing page if they join a new game, and are forwarded to the game from anywhere if they join a real time game (no matter whether they accept the game or someone else does). 
- The next game button works again and this time: game disappears on timeout from the next game button and unanswered game controls trigger the next game button too.