### PR TITLE
Rematch

### DIFF
--- a/apis/src/components/atoms/game_type.rs
+++ b/apis/src/components/atoms/game_type.rs
@@ -1,0 +1,24 @@
+use leptos::*;
+
+#[component]
+pub fn GameType(game_type: String) -> impl IntoView {
+    view! {
+        <div class="flex justify-center">
+            {if game_type == "Base" {
+                view! { "—" }.into_view()
+            } else {
+                view! {
+                    <img
+                        width="100%"
+                        height="100%"
+                        src="/assets/plm.svg"
+                        alt="plm"
+                        class="w-14 lg:w-20"
+                    />
+                }
+                    .into_view()
+            }}
+
+        </div>
+    }
+}

--- a/apis/src/components/atoms/mod.rs
+++ b/apis/src/components/atoms/mod.rs
@@ -1,4 +1,5 @@
 pub mod active;
+pub mod game_type;
 pub mod gc_button;
 pub mod hex;
 pub mod history_button;

--- a/apis/src/components/organisms/challenges.rs
+++ b/apis/src/components/organisms/challenges.rs
@@ -1,13 +1,69 @@
 use crate::{
-    components::molecules::challenge_row::ChallengeRow, responses::challenge::ChallengeResponse,
+    components::molecules::challenge_row::ChallengeRow,
+    providers::{auth_context::AuthContext, challenges::ChallengeStateSignal},
+    responses::challenge::ChallengeResponse,
 };
 use leptos::*;
-use std::collections::HashMap;
 
 #[component]
-pub fn Challenges(challenges: HashMap<String, ChallengeResponse>) -> impl IntoView {
+pub fn Challenges() -> impl IntoView {
     let th_class = "py-1 px-1 md:py-2 md:px-2 lg:px-3 font-bold uppercase max-h-[80vh]";
-    let challenges = store_value(challenges);
+    let challenges = expect_context::<ChallengeStateSignal>();
+    let auth_context = expect_context::<AuthContext>();
+    let user = move || {
+        if let Some(Ok(Some(user))) = (auth_context.user)() {
+            Some(user)
+        } else {
+            None
+        }
+    };
+    let direct = move || {
+        if let Some(user) = user() {
+            // Get the challenges direct at the current user
+            challenges
+                .signal
+                .get()
+                .challenges
+                .values().filter(|&challenge| challenge.clone().opponent.is_some_and(|o| o.uid == user.id)).cloned()
+                .collect::<Vec<ChallengeResponse>>()
+        } else {
+            challenges
+                .signal
+                .get()
+                .challenges
+                .values()
+                .cloned()
+                .collect::<Vec<ChallengeResponse>>()
+        }
+    };
+
+    let own = move || {
+        if let Some(user) = user() {
+            challenges
+                .signal
+                .get()
+                .challenges
+                .values().filter(|&challenge| challenge.challenger.uid == user.id).cloned()
+                .collect::<Vec<ChallengeResponse>>()
+        } else {
+            Vec::new()
+        }
+    };
+
+    let public = move || {
+        if let Some(user) = user() {
+            challenges
+                .signal
+                .get()
+                .challenges
+                .values().filter(|&challenge| {
+                    challenge.clone().opponent.is_none() && challenge.challenger.uid != user.id
+                }).cloned()
+                .collect::<Vec<ChallengeResponse>>()
+        } else {
+            Vec::new()
+        }
+    };
     view! {
         <div class="flex col-span-full overflow-x-auto">
             <table class="grow md:grow-0 md:table-fixed">
@@ -22,30 +78,31 @@ pub fn Challenges(challenges: HashMap<String, ChallengeResponse>) -> impl IntoVi
                         <th class=th_class>Action</th>
                     </tr>
                 </thead>
-                <Show
-                    when=move || challenges().is_empty()
-                    fallback=move || {
-                        view! {
-                            <tbody>
-
-                                <For
-                                    each=move || { challenges() }
-                                    key=|(key, _)| key.to_owned()
-                                    let:one_challenge
-                                >
-                                    <ChallengeRow
-                                        challenge=store_value(one_challenge.1)
-                                        single=false
-                                    />
-                                </For>
-
-                            </tbody>
-                        }
-                    }
-                >
-
-                    ""
-                </Show>
+                <tbody>
+                    <For
+                        each=move || { direct() }
+                        key=|c| c.nanoid.to_owned()
+                        let:challenge
+                    >
+                        <ChallengeRow challenge=store_value(challenge.to_owned()) single=false/>
+                    </For>
+                    <tr class="h-2"> </tr>
+                    <For
+                        each=move || { own() }
+                        key=|c| c.nanoid.to_owned()
+                        let:challenge
+                    >
+                        <ChallengeRow challenge=store_value(challenge.to_owned()) single=false/>
+                    </For>
+                    <tr class="h-2"> </tr>
+                    <For
+                        each=move || { public() }
+                        key=|c| c.nanoid.to_owned()
+                        let:challenge
+                    >
+                        <ChallengeRow challenge=store_value(challenge.to_owned()) single=false/>
+                    </For>
+                </tbody>
             </table>
         </div>
     }

--- a/apis/src/pages/home.rs
+++ b/apis/src/pages/home.rs
@@ -1,16 +1,11 @@
 use crate::components::{molecules::modal::Modal, organisms::challenges::Challenges};
 use crate::pages::challenge_create::ChallengeCreate;
 use crate::providers::auth_context::AuthContext;
-use crate::providers::challenges::ChallengeStateSignal;
 use leptos::{html::Dialog, *};
-use uuid::Uuid;
 
 #[component]
 pub fn Home() -> impl IntoView {
     let auth_context = expect_context::<AuthContext>();
-    // showing public games or own challenges
-    let show_public = create_rw_signal(true);
-    // if modal is open
     let open = create_rw_signal(false);
     let dialog_el = create_node_ref::<Dialog>();
     let close_modal = Callback::new(move |()| {
@@ -20,15 +15,11 @@ pub fn Home() -> impl IntoView {
             .close();
     });
 
-    let source_signal: RwSignal<Option<Uuid>> = create_rw_signal(None);
-    let challenge_state = expect_context::<ChallengeStateSignal>();
-    let own_challenges = move || challenge_state.signal.get().own;
-    let public_challenges = move || challenge_state.signal.get().public;
-    let button_color = move || {
-        if show_public() {
-            ("bg-slate-400", "bg-inherit")
+    let logged_in = move || {
+        if let Some(Ok(Some(_))) = (auth_context.user)() {
+            true
         } else {
-            ("bg-inherit", "bg-slate-400")
+            false
         }
     };
 
@@ -40,79 +31,26 @@ pub fn Home() -> impl IntoView {
             >
                 Leaderboard and online players
             </a>
-            <Transition>
-                {move || {
-                    let user = move || match (auth_context.user)() {
-                        Some(Ok(Some(user))) => {
-                            source_signal.update(move |v| *v = Some(user.id));
-                            Some(user)
-                        }
-                        _ => {
-                            source_signal.update(move |v| *v = None);
-                            None
-                        }
-                    };
-                    let challenge = move || {
-                        view! { <Challenges challenges=public_challenges()/> }
-                    };
-                    let own = move || {
-                        view! { <Challenges challenges=own_challenges()/> }
-                    };
-                    view! {
-                        <div class="pt-5 flex flex-col md:flex-row justify-center">
-                            <Show when=move || user().is_some() fallback=challenge>
-                                <Modal open=open dialog_el=dialog_el>
-                                    <ChallengeCreate close=close_modal/>
-                                </Modal>
-                                <div class="flex justify-center">
-                                    <div class="flex flex-col max-w-fit w-full">
-                                        <div class="flex justify-between">
-                                            <button
-                                                class=move || {
-                                                    format!(
-                                                        "grow hover:bg-blue-300 duration-300 {}",
-                                                        button_color().0,
-                                                    )
-                                                }
-
-                                                on:click=move |_| { show_public.update(|b| *b = true) }
-                                            >
-                                                Lobby
-                                            </button>
-                                            <button
-                                                class=move || {
-                                                    format!(
-                                                        "grow hover:bg-blue-300 duration-300 {}",
-                                                        button_color().1,
-                                                    )
-                                                }
-
-                                                on:click=move |_| { show_public.update(|b| *b = false) }
-                                            >
-                                                My Challenges
-                                            </button>
-                                        </div>
-                                        <Show when=show_public fallback=own>
-                                            {challenge}
-                                        </Show>
-                                    </div>
-
-                                </div>
-                                <div class="flex md:flex-col">
-                                    <button
-                                        class="m-5 md:mt-20 grow md:grow-0 whitespace-nowrap bg-blue-500 hover:bg-blue-700 duration-300 text-white font-bold py-2 px-4 rounded"
-                                        on:click=move |_| open.update(move |b| *b = true)
-                                    >
-                                        Create New Game
-                                    </button>
-                                </div>
-                            </Show>
-
-                        </div>
-                    }
-                }}
-
-            </Transition>
+            <div class="pt-5 flex flex-col md:flex-row justify-center">
+                <Modal open=open dialog_el=dialog_el>
+                    <ChallengeCreate close=close_modal/>
+                </Modal>
+                <div class="flex justify-center">
+                    <div class="flex flex-col max-w-fit w-full">
+                        <Challenges/>
+                    </div>
+                </div>
+                <Show when=logged_in>
+                    <div class="flex md:flex-col">
+                        <button
+                            class="m-5 md:mt-14 grow md:grow-0 whitespace-nowrap bg-blue-500 hover:bg-blue-700 duration-300 text-white font-bold py-2 px-4 rounded"
+                            on:click=move |_| open.update(move |b| *b = true)
+                        >
+                            Create New Game
+                        </button>
+                    </div>
+                </Show>
+            </div>
         </div>
     }
 }

--- a/apis/src/providers/api_requests.rs
+++ b/apis/src/providers/api_requests.rs
@@ -59,6 +59,12 @@ impl ApiRequests {
             .send(&serde_json::to_string(&msg).expect("Serde_json::to_string failed"));
     }
 
+    pub fn challenge_direct(&self, challenge_action: ChallengeAction) {
+        let msg = ClientRequest::Challenge(challenge_action);
+        self.websocket
+            .send(&serde_json::to_string(&msg).expect("Serde_json::to_string failed"));
+    }
+
     pub fn challenge_new_with_params(&self, params: ChallengeParams) {
         let msg = ClientRequest::Challenge(ChallengeAction::Create {
             rated: params.rated.get_untracked(),

--- a/apis/src/providers/challenges.rs
+++ b/apis/src/providers/challenges.rs
@@ -1,7 +1,6 @@
 use crate::responses::challenge::ChallengeResponse;
 use leptos::*;
 use std::collections::HashMap;
-use uuid::Uuid;
 
 #[derive(Clone, Debug, Copy)]
 pub struct ChallengeStateSignal {
@@ -23,33 +22,14 @@ impl ChallengeStateSignal {
 
     pub fn remove(&mut self, nanoid: String) {
         self.signal.update(|s| {
-            s.own.remove(&nanoid);
-            s.direct.remove(&nanoid);
-            s.public.remove(&nanoid);
+            s.challenges.remove(&nanoid);
         });
     }
 
-    pub fn add(&mut self, challenges: Vec<ChallengeResponse>, user_id: Option<Uuid>) {
-        self.signal.update(|s| match user_id {
-            Some(id) => {
-                for c in challenges {
-                    if c.challenger.uid == id {
-                        s.own.insert(c.nanoid.to_owned(), c.to_owned());
-                        continue;
-                    }
-                    if let Some(ref opponent) = c.opponent {
-                        if opponent.uid == id {
-                            s.direct.insert(c.nanoid.to_owned(), c.to_owned());
-                            continue;
-                        }
-                    }
-                    s.public.insert(c.nanoid.to_owned(), c.to_owned());
-                }
-            }
-            None => {
-                for c in challenges {
-                    s.public.insert(c.nanoid.to_owned(), c);
-                }
+    pub fn add(&mut self, challenges: Vec<ChallengeResponse>) {
+        self.signal.update(|s| {
+            for challenge in challenges {
+                s.challenges.insert(challenge.nanoid.to_owned(), challenge);
             }
         })
     }
@@ -57,17 +37,13 @@ impl ChallengeStateSignal {
 
 #[derive(Clone, Debug)]
 pub struct ChallengeState {
-    pub public: HashMap<String, ChallengeResponse>,
-    pub own: HashMap<String, ChallengeResponse>,
-    pub direct: HashMap<String, ChallengeResponse>,
+    pub challenges: HashMap<String, ChallengeResponse>,
 }
 
 impl ChallengeState {
     pub fn new() -> Self {
         Self {
-            public: HashMap::new(),
-            own: HashMap::new(),
-            direct: HashMap::new(),
+            challenges: HashMap::new(),
         }
     }
 }

--- a/apis/src/providers/web_socket.rs
+++ b/apis/src/providers/web_socket.rs
@@ -215,17 +215,8 @@ fn on_message_callback(m: String) {
         Ok(ServerResult::Ok(ServerMessage::Challenge(ChallengeUpdate::Challenges(
             new_challanges,
         )))) => {
-            for chal in new_challanges.clone() {
-                log!("Got new challenge: {}", chal.nanoid);
-            }
             let mut challenges = expect_context::<ChallengeStateSignal>();
-            let auth_context = expect_context::<AuthContext>();
-            let user_uuid = move || match untrack(auth_context.user) {
-                Some(Ok(Some(user))) => Some(user.id),
-                _ => None,
-            };
-            log!("User is: {:?}", user_uuid());
-            challenges.add(new_challanges, user_uuid());
+            challenges.add(new_challanges);
         }
         Ok(ServerResult::Ok(ServerMessage::GameTimeoutCheck(game))) => {
             let mut game_state = expect_context::<GameStateSignal>();
@@ -278,12 +269,7 @@ fn on_message_callback(m: String) {
         Ok(ServerResult::Ok(ServerMessage::Challenge(ChallengeUpdate::Created(challenge))))
         | Ok(ServerResult::Ok(ServerMessage::Challenge(ChallengeUpdate::Direct(challenge)))) => {
             let mut challenges = expect_context::<ChallengeStateSignal>();
-            let auth_context = expect_context::<AuthContext>();
-            let user_uuid = move || match untrack(auth_context.user) {
-                Some(Ok(Some(user))) => Some(user.id),
-                _ => None,
-            };
-            challenges.add(vec![challenge], user_uuid());
+            challenges.add(vec![challenge]);
         }
         Ok(ServerResult::Err(e)) => log!("Got error from server: {e}"),
         Err(e) => log!("Can't parse: {m}, error is: {e}"),

--- a/apis/src/websockets/api/challenges/delete.rs
+++ b/apis/src/websockets/api/challenges/delete.rs
@@ -29,7 +29,7 @@ impl DeleteHandler {
 
     pub async fn handle(&self) -> Result<Vec<InternalServerMessage>> {
         let challenge = Challenge::find_by_nanoid(&self.nanoid, &self.pool).await?;
-        if challenge.challenger_id != self.user_id {
+        if challenge.challenger_id != self.user_id && challenge.opponent_id != Some(self.user_id) {
             return Err(ChallengeError::NotUserChallenge.into());
         }
         let challenge_response = ChallengeResponse::from_model(&challenge, &self.pool).await?;

--- a/apis/src/websockets/lobby.rs
+++ b/apis/src/websockets/lobby.rs
@@ -186,6 +186,14 @@ impl Handler<Connect> for Lobby {
                         }
                     }
                 }
+                if let Ok(challenges) = Challenge::direct_challenges(user.id, &pool).await {
+                    for challenge in challenges {
+                        if let Ok(response) = ChallengeResponse::from_model(&challenge, &pool).await
+                        {
+                            responses.push(response);
+                        }
+                    }
+                }
                 let message = ServerResult::Ok(ServerMessage::Challenge(
                     ChallengeUpdate::Challenges(responses),
                 ));

--- a/db/src/models/challenge.rs
+++ b/db/src/models/challenge.rs
@@ -90,6 +90,12 @@ impl NewChallenge {
                 })
             }
         }
+        if opponent_id == Some(challenger_id) {
+            return Err(DbError::InvalidInput {
+                info: "You can't play here with yourself.".to_string(),
+                error: String::new(),
+            });
+        };
         Ok(Self {
             nanoid: nanoid!(10),
             challenger_id,
@@ -165,7 +171,7 @@ impl Challenge {
             .await?)
     }
 
-    pub async fn direct_challenges(id: &Uuid, pool: &DbPool) -> Result<Vec<Challenge>, DbError> {
+    pub async fn direct_challenges(id: Uuid, pool: &DbPool) -> Result<Vec<Challenge>, DbError> {
         let conn = &mut get_conn(pool).await?;
         Ok(challenges::table
             .filter(opponent_id_field.eq(id))


### PR DESCRIPTION
Finishes the backend implementation of direct challenges and hooks up the "rematch" button so that you can directly challenge the game's opponent to another game.
Reworks how challenges are displayed on the landing page too. 