### PR TITLE
Adds drop shadow via svg

### DIFF
--- a/apis/src/components/atoms/piece.rs
+++ b/apis/src/components/atoms/piece.rs
@@ -55,52 +55,28 @@ pub fn Piece(
         }
     };
 
-    //IMPORTANT drop-shadow-b drop-shadow-w leave this comment for TW
-    let mut filter = match game_state_signal
+    let drop_shadow = if match game_state_signal
         .signal
         .get_untracked()
         .state
         .board
         .last_move
     {
-        (Some(_), Some(to)) => {
-            if position.get_untracked() == to {
-                String::new()
-            } else {
-                format!(
-                    "duration-300 translateZ(0) transform-gpu drop-shadow-{}",
-                    &color.to_string()
-                )
-            }
-        }
-        (Some(pos), None) => {
-            if position.get_untracked() == pos {
-                String::new()
-            } else {
-                format!(
-                    "duration-300 translateZ(0) transform-gpu drop-shadow-{}",
-                    &color.to_string()
-                )
-            }
-        }
-        (None, Some(pos)) => {
-            if position.get_untracked() == pos {
-                String::new()
-            } else {
-                format!(
-                    "duration-300 translateZ(0) transform-gpu drop-shadow-{}",
-                    &color.to_string()
-                )
-            }
-        }
-        _ => format!(
-            "duration-300 translateZ(0) transform-gpu drop-shadow-{}",
-            &color.to_string()
-        ),
+        (Some(_), Some(to)) => position.get_untracked() != to,
+        (Some(pos), None) => position.get_untracked() != pos,
+        (None, Some(pos)) => position.get_untracked() != pos,
+        _ => true,
+    } {
+        "#ds"
+    } else {
+        "#no-ds"
     };
-    if piece_type == PieceType::Inactive {
-        filter.push_str(" sepia-[.75]");
-    }
+
+    let sepia = if piece_type == PieceType::Inactive {
+        "sepia-[.75]"
+    } else {
+        ""
+    };
 
     let mut game_state_signal = expect_context::<GameStateSignal>();
     let in_analysis = use_context::<InAnalysis>().unwrap_or(InAnalysis(RwSignal::new(false)));
@@ -167,10 +143,10 @@ pub fn Piece(
     };
 
     view! {
-        <g on:click=onclick class=filter style=dot_color>
+        <g on:click=onclick class=sepia style=dot_color>
             <g transform=transform>
+                <use_ href=drop_shadow transform="scale(0.56, 0.56) translate(-67, -64.5)"></use_>
                 <use_ href=tile_svg transform="scale(0.56, 0.56) translate(-45, -50)"></use_>
-                // TODO: Fix svgs to have the same numbers
                 <use_ href=bug_svg transform=bug_transform></use_>
                 <use_ href=dots transform="scale(0.56, 0.56) translate(-45, -50)"></use_>
             </g>

--- a/apis/src/components/atoms/svgs.rs
+++ b/apis/src/components/atoms/svgs.rs
@@ -4,6 +4,25 @@ use leptos::*;
 pub fn Svgs() -> impl IntoView {
     view! {
         <svg visibility="hidden" xmlns="http://www.w3.org/2000/svg">
+            <defs id="defs166">
+                <clipPath clipPathUnits="userSpaceOnUse" id="clipPath23-3">
+                    <path
+                        d="M 0,841.89 H 595.275 V 0 H 0 Z"
+                        transform="translate(-308.47071,-688.47362)"
+                        id="path23-6"
+                    ></path>
+                </clipPath>
+                <filter
+                    style="color-interpolation-filters:sRGB"
+                    id="filter1"
+                    x="-0.025635776"
+                    y="-0.028579977"
+                    width="1.0512716"
+                    height="1.05716"
+                >
+                    <feGaussianBlur stdDeviation="0.63602629" id="feGaussianBlur1"></feGaussianBlur>
+                </filter>
+            </defs>
             // common among designs
             <g id="target" transform="translate(-55.302105,-46.379573)">
                 <path
@@ -88,6 +107,38 @@ pub fn Svgs() -> impl IntoView {
                     cy="48.452221"
                     r="2.5356171"
                 ></circle>
+            </g>
+            <g id="ds">
+                <defs id="defs166">
+                    <clipPath clipPathUnits="userSpaceOnUse" id="clipPath23-3">
+                        <path
+                            d="M 0,841.89 H 595.275 V 0 H 0 Z"
+                            transform="translate(-308.47071,-688.47362)"
+                            id="path23-6"
+                        ></path>
+                    </clipPath>
+                    <filter
+                        style="color-interpolation-filters:sRGB"
+                        id="filter1"
+                        x="-0.025635776"
+                        y="-0.028579977"
+                        width="1.0512716"
+                        height="1.05716"
+                    >
+                        <feGaussianBlur
+                            stdDeviation="0.63602629"
+                            id="feGaussianBlur1"
+                        ></feGaussianBlur>
+                    </filter>
+                </defs>
+
+                <path
+                    id="path22-5"
+                    d="m 0,0 c 1.322,0.202 2.578,0.787 3.592,1.708 0.517,0.473 0.974,1.029 1.342,1.671 0.326,0.572 11.761,19.972 12.074,20.942 0.4,1.238 0.451,2.581 0.105,3.877 -0.15,0.567 -0.369,1.124 -0.674,1.657 -0.283,0.496 -11.474,20.355 -12.078,21.052 -0.855,0.99 -1.986,1.732 -3.275,2.108 -0.611,0.176 -1.254,0.277 -1.922,0.277 -0.607,0 -23.293,0.147 -24.033,0.032 -1.32,-0.204 -2.572,-0.79 -3.582,-1.711 -0.516,-0.469 -0.971,-1.025 -1.336,-1.665 -0.324,-0.569 -11.76,-19.973 -12.072,-20.929 -0.407,-1.242 -0.457,-2.589 -0.116,-3.888 0.153,-0.571 0.371,-1.133 0.68,-1.669 0.285,-0.498 11.469,-20.347 12.078,-21.05 0.856,-0.987 1.987,-1.727 3.274,-2.1 0.609,-0.178 1.25,-0.278 1.916,-0.278 C -23.422,0.034 -0.73,-0.112 0,0"
+                    style="opacity:0.549569;fill:#999999;fill-opacity:1;fill-rule:nonzero;stroke:none;filter:url(#filter1)"
+                    transform="matrix(1.4542878,-0.83963345,-0.83963345,-1.4542878,109.68343,95.675975)"
+                    clip-path="url(#clipPath23-3)"
+                ></path>
             </g>
             <g id="b">
                 <path


### PR DESCRIPTION
This is purely needed because Safari is a subpar browser and cannot render css filter drop shadows correctly...